### PR TITLE
Fix: まとめて予約モーダルがスマートフォンではみ出す問題を修正

### DIFF
--- a/app/(protected)/ems/equipment-list/page.tsx
+++ b/app/(protected)/ems/equipment-list/page.tsx
@@ -414,7 +414,7 @@ const EquipmentList = () => {
                                 leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                             >
-                                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full max-w-lg sm:p-6">
                                     <div>
                                         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
                                             <CheckIcon className="h-6 w-6 text-green-600" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- まとめて予約モーダルの日付入力ボックスがスマートフォン表示でバナーの枠を超えてはみ出す問題を修正
- `Dialog.Panel`の幅設定を`sm:w-full sm:max-w-lg`から`w-full max-w-lg`に変更し、全ての画面サイズで適切に表示されるようにした

## Test plan
- [x] スマートフォン（または開発者ツールのモバイル表示）でまとめて予約モーダルを開き、はみ出しがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)