### PR TITLE
fix: スマホ環境でまとめて予約の日付入力がはみ出る問題を修正

### DIFF
--- a/app/(protected)/ems/equipment-list/page.tsx
+++ b/app/(protected)/ems/equipment-list/page.tsx
@@ -449,7 +449,7 @@ const EquipmentList = () => {
                                                         name="start"
                                                         value={bulkReservation.start}
                                                         onChange={(e) => setBulkReservation({ ...bulkReservation, start: e.target.value })}
-                                                        className="mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 text-gray-900 focus:border-violet-500 focus:ring-violet-500"
+                                                        className="mt-1 block w-full min-w-0 max-w-full rounded-md border border-gray-300 py-2 px-3 text-gray-900 focus:border-violet-500 focus:ring-violet-500"
                                                     />
                                                 </div>
                                                 <div className="mt-4">
@@ -459,7 +459,7 @@ const EquipmentList = () => {
                                                         name="end"
                                                         value={bulkReservation.end}
                                                         onChange={(e) => setBulkReservation({ ...bulkReservation, end: e.target.value })}
-                                                        className="mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 text-gray-900 focus:border-violet-500 focus:ring-violet-500"
+                                                        className="mt-1 block w-full min-w-0 max-w-full rounded-md border border-gray-300 py-2 px-3 text-gray-900 focus:border-violet-500 focus:ring-violet-500"
                                                     />
                                                 </div>
                                                 <div className="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">


### PR DESCRIPTION
## Summary
- まとめて予約モーダルの日付入力（開始日・終了日）がスマホ環境で外枠を右にはみ出して表示される問題を修正
- `min-w-0` と `max-w-full` を追加してdate inputのデフォルト最小幅をリセット

## Test plan
- [ ] スマホ環境でまとめて予約モーダルを開き、日付入力がモーダル内に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)