### PR TITLE
fix: まとめて予約モーダルの日付入力フィールドに左右均等のパディングを追加

### DIFF
--- a/app/(protected)/ems/equipment-list/page.tsx
+++ b/app/(protected)/ems/equipment-list/page.tsx
@@ -441,7 +441,7 @@ const EquipmentList = () => {
                                                     </div>
                                                 </div>
                                             </div>
-                                            <form onSubmit={handleBulkSubmit}>
+                                            <form onSubmit={handleBulkSubmit} className="px-4">
                                                 <div className="mt-4">
                                                     <label className="block text-sm font-medium text-gray-700 text-left">開始日</label>
                                                     <input


### PR DESCRIPTION
formタグにpx-4クラスを追加して、開始日・終了日の入力フィールドが
左右均等な余白を持つように修正