### PR TITLE
feat: add Vitest test infrastructure and consolidate domain types

### DIFF
--- a/actions/login.test.ts
+++ b/actions/login.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { MockAuthError } = vi.hoisted(() => {
+  class MockAuthError extends Error {
+    type: string;
+    constructor(type: string, message?: string) {
+      super(message);
+      this.type = type;
+    }
+  }
+  return { MockAuthError };
+});
+
+vi.mock("next-auth", () => ({
+  AuthError: MockAuthError,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    twoFactorToken: { delete: vi.fn() },
+    twoFactorConfirmation: { delete: vi.fn(), create: vi.fn() },
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  signIn: vi.fn(),
+}));
+
+vi.mock("@/data/user", () => ({
+  getUserByEmail: vi.fn(),
+}));
+
+vi.mock("@/data/two-factor-token", () => ({
+  getTwoFactorTokenByEmail: vi.fn(),
+}));
+
+vi.mock("@/data/two-factor-confirmation", () => ({
+  getTwoFactorConfirmationByUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/mail", () => ({
+  sendVerificationEmail: vi.fn(),
+  sendTwoFactorTokenEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/tokens", () => ({
+  generateVerificationToken: vi.fn(),
+  generateTwoFactorToken: vi.fn(),
+}));
+
+import { signIn } from "@/auth";
+import { getUserByEmail } from "@/data/user";
+import { getTwoFactorTokenByEmail } from "@/data/two-factor-token";
+import { getTwoFactorConfirmationByUserId } from "@/data/two-factor-confirmation";
+import { sendVerificationEmail, sendTwoFactorTokenEmail } from "@/lib/mail";
+import { generateVerificationToken, generateTwoFactorToken } from "@/lib/tokens";
+import { db } from "@/lib/db";
+import { login } from "./login";
+
+const verifiedUser = {
+  id: "u1",
+  email: "a@b.com",
+  password: "hashed",
+  emailVerified: new Date(),
+  isTwoFactorEnabled: false,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("login - input validation", () => {
+  it("returns error on invalid input", async () => {
+    const result = await login({ email: "bad", password: "" });
+    expect(result).toEqual({ error: "入力に誤りがあります！" });
+    expect(getUserByEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("login - user lookup", () => {
+  it("returns error when user does not exist", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(null);
+    const result = await login({ email: "missing@b.com", password: "anything" });
+    expect(result).toEqual({ error: "存在しないメールアドレスです！" });
+  });
+
+  it("returns error when user has no password (OAuth-only)", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({ ...verifiedUser, password: null } as never);
+    const result = await login({ email: "a@b.com", password: "anything" });
+    expect(result).toEqual({ error: "存在しないメールアドレスです！" });
+  });
+});
+
+describe("login - email verification", () => {
+  it("sends verification email and returns success when email not verified", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({ ...verifiedUser, emailVerified: null } as never);
+    vi.mocked(generateVerificationToken).mockResolvedValue({
+      email: "a@b.com",
+      token: "vt",
+    } as never);
+
+    const result = await login({ email: "a@b.com", password: "anything" });
+
+    expect(generateVerificationToken).toHaveBeenCalledWith("a@b.com");
+    expect(sendVerificationEmail).toHaveBeenCalledWith("a@b.com", "vt");
+    expect(result).toEqual({ success: "確認メールを送信しました！" });
+  });
+});
+
+describe("login - 2FA flow without code", () => {
+  it("sends 2FA token and returns twoFactor flag", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      ...verifiedUser,
+      isTwoFactorEnabled: true,
+    } as never);
+    vi.mocked(generateTwoFactorToken).mockResolvedValue({
+      email: "a@b.com",
+      token: "123456",
+    } as never);
+
+    const result = await login({ email: "a@b.com", password: "anything" });
+
+    expect(generateTwoFactorToken).toHaveBeenCalledWith("a@b.com");
+    expect(sendTwoFactorTokenEmail).toHaveBeenCalledWith("a@b.com", "123456");
+    expect(result).toEqual({ twoFactor: true });
+    expect(signIn).not.toHaveBeenCalled();
+  });
+});
+
+describe("login - 2FA flow with code", () => {
+  it("returns error when no 2FA token exists for user", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      ...verifiedUser,
+      isTwoFactorEnabled: true,
+    } as never);
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue(null);
+
+    const result = await login({ email: "a@b.com", password: "anything", code: "123456" });
+    expect(result).toEqual({ error: "無効なコードです！" });
+  });
+
+  it("returns error when code does not match", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      ...verifiedUser,
+      isTwoFactorEnabled: true,
+    } as never);
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue({
+      id: "tt",
+      token: "999999",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+
+    const result = await login({ email: "a@b.com", password: "anything", code: "123456" });
+    expect(result).toEqual({ error: "無効なコードです！" });
+  });
+
+  it("returns error when code has expired", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      ...verifiedUser,
+      isTwoFactorEnabled: true,
+    } as never);
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue({
+      id: "tt",
+      token: "123456",
+      expires: new Date(Date.now() - 60_000),
+    } as never);
+
+    const result = await login({ email: "a@b.com", password: "anything", code: "123456" });
+    expect(result).toEqual({ error: "コードの有効期限が切れています！" });
+  });
+
+  it("deletes token, creates confirmation, and proceeds to signIn on valid code", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      ...verifiedUser,
+      isTwoFactorEnabled: true,
+    } as never);
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue({
+      id: "tt",
+      token: "123456",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+    vi.mocked(getTwoFactorConfirmationByUserId).mockResolvedValue(null);
+    vi.mocked(signIn).mockResolvedValue(undefined as never);
+
+    await login({ email: "a@b.com", password: "anything", code: "123456" });
+
+    expect(db.twoFactorToken.delete).toHaveBeenCalledWith({ where: { id: "tt" } });
+    expect(db.twoFactorConfirmation.create).toHaveBeenCalledWith({
+      data: { userId: "u1" },
+    });
+    expect(signIn).toHaveBeenCalled();
+  });
+
+  it("deletes existing confirmation before creating a new one", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      ...verifiedUser,
+      isTwoFactorEnabled: true,
+    } as never);
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue({
+      id: "tt",
+      token: "123456",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+    vi.mocked(getTwoFactorConfirmationByUserId).mockResolvedValue({ id: "c-old" } as never);
+    vi.mocked(signIn).mockResolvedValue(undefined as never);
+
+    await login({ email: "a@b.com", password: "anything", code: "123456" });
+
+    expect(db.twoFactorConfirmation.delete).toHaveBeenCalledWith({ where: { id: "c-old" } });
+    expect(db.twoFactorConfirmation.create).toHaveBeenCalled();
+  });
+});
+
+describe("login - signIn errors", () => {
+  it("returns invalid credentials error when signIn throws CredentialsSignin", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(verifiedUser as never);
+    vi.mocked(signIn).mockRejectedValue(new MockAuthError("CredentialsSignin"));
+
+    const result = await login({ email: "a@b.com", password: "anything" });
+    expect(result).toEqual({ error: "Emailかパスワードに間違いがあります！" });
+  });
+
+  it("returns generic error on other AuthError types", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(verifiedUser as never);
+    vi.mocked(signIn).mockRejectedValue(new MockAuthError("Verification"));
+
+    const result = await login({ email: "a@b.com", password: "anything" });
+    expect(result).toEqual({ error: "something went wrong!" });
+  });
+
+  it("re-throws non-AuthError errors", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(verifiedUser as never);
+    vi.mocked(signIn).mockRejectedValue(new Error("redirect"));
+
+    await expect(login({ email: "a@b.com", password: "anything" })).rejects.toThrow("redirect");
+  });
+});

--- a/actions/new-password.test.ts
+++ b/actions/new-password.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: { update: vi.fn() },
+    passwordResetToken: { delete: vi.fn() },
+  },
+}));
+
+vi.mock("@/data/user", () => ({
+  getUserByEmail: vi.fn(),
+}));
+
+vi.mock("@/data/password-reset-token", () => ({
+  getPasswordResetTokenByToken: vi.fn(),
+}));
+
+vi.mock("bcryptjs", () => ({
+  default: { hash: vi.fn(async () => "hashed-new") },
+}));
+
+import { db } from "@/lib/db";
+import { getUserByEmail } from "@/data/user";
+import { getPasswordResetTokenByToken } from "@/data/password-reset-token";
+import { newPassword } from "./new-password";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("newPassword", () => {
+  const validInput = { password: "tenchars12" };
+
+  it("returns error when token is missing", async () => {
+    const result = await newPassword(validInput, null);
+    expect(result).toEqual({ error: "トークンがありません！" });
+  });
+
+  it("returns error on invalid password input", async () => {
+    const result = await newPassword({ password: "short" }, "tok");
+    expect(result).toEqual({ error: "無効な入力です！" });
+  });
+
+  it("returns error when reset token does not exist", async () => {
+    vi.mocked(getPasswordResetTokenByToken).mockResolvedValue(null);
+
+    const result = await newPassword(validInput, "tok");
+    expect(result).toEqual({ error: "無効なトークンです！" });
+  });
+
+  it("returns error when token has expired", async () => {
+    vi.mocked(getPasswordResetTokenByToken).mockResolvedValue({
+      id: "t1",
+      email: "a@b.com",
+      expires: new Date(Date.now() - 60_000),
+    } as never);
+
+    const result = await newPassword(validInput, "tok");
+    expect(result).toEqual({ error: "トークンの有効期限が切れています！" });
+  });
+
+  it("returns error when user does not exist", async () => {
+    vi.mocked(getPasswordResetTokenByToken).mockResolvedValue({
+      id: "t1",
+      email: "a@b.com",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+    vi.mocked(getUserByEmail).mockResolvedValue(null);
+
+    const result = await newPassword(validInput, "tok");
+    expect(result).toEqual({ error: "存在しないメールアドレスです！" });
+  });
+
+  it("updates password, deletes token, and returns success", async () => {
+    vi.mocked(getPasswordResetTokenByToken).mockResolvedValue({
+      id: "t1",
+      email: "a@b.com",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+    vi.mocked(getUserByEmail).mockResolvedValue({ id: "u1" } as never);
+
+    const result = await newPassword(validInput, "tok");
+
+    expect(db.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { password: "hashed-new" },
+    });
+    expect(db.passwordResetToken.delete).toHaveBeenCalledWith({
+      where: { id: "t1" },
+    });
+    expect(result).toEqual({ success: "パスワードが再設定されました！" });
+  });
+});

--- a/actions/new-verification.test.ts
+++ b/actions/new-verification.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: { update: vi.fn() },
+    verificationToken: { delete: vi.fn() },
+  },
+}));
+
+vi.mock("@/data/user", () => ({
+  getUserByEmail: vi.fn(),
+}));
+
+vi.mock("@/data/verification-token", () => ({
+  getVerificationTokenByToken: vi.fn(),
+}));
+
+import { db } from "@/lib/db";
+import { getUserByEmail } from "@/data/user";
+import { getVerificationTokenByToken } from "@/data/verification-token";
+import { newVerification } from "./new-verification";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("newVerification", () => {
+  it("returns error when token does not exist", async () => {
+    vi.mocked(getVerificationTokenByToken).mockResolvedValue(null);
+
+    const result = await newVerification("tok");
+    expect(result).toEqual({ error: "トークンが存在しません！" });
+  });
+
+  it("returns error when token has expired", async () => {
+    vi.mocked(getVerificationTokenByToken).mockResolvedValue({
+      id: "t1",
+      email: "a@b.com",
+      expires: new Date(Date.now() - 60_000),
+    } as never);
+
+    const result = await newVerification("tok");
+    expect(result).toEqual({ error: "トークンの有効期限が切れています！" });
+  });
+
+  it("returns error when user does not exist", async () => {
+    vi.mocked(getVerificationTokenByToken).mockResolvedValue({
+      id: "t1",
+      email: "a@b.com",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+    vi.mocked(getUserByEmail).mockResolvedValue(null);
+
+    const result = await newVerification("tok");
+    expect(result).toEqual({ error: "存在しないメールアドレスです！" });
+  });
+
+  it("verifies email, deletes token, and returns success", async () => {
+    vi.mocked(getVerificationTokenByToken).mockResolvedValue({
+      id: "t1",
+      email: "a@b.com",
+      expires: new Date(Date.now() + 60_000),
+    } as never);
+    vi.mocked(getUserByEmail).mockResolvedValue({ id: "u1" } as never);
+
+    const result = await newVerification("tok");
+
+    expect(db.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { emailVerified: expect.any(Date), email: "a@b.com" },
+    });
+    expect(db.verificationToken.delete).toHaveBeenCalledWith({
+      where: { id: "t1" },
+    });
+    expect(result).toEqual({ success: "メールアドレスが認証されました！" });
+  });
+});

--- a/actions/register.test.ts
+++ b/actions/register.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: { create: vi.fn() },
+  },
+}));
+
+vi.mock("@/data/user", () => ({
+  getUserByEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/mail", () => ({
+  sendVerificationEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/tokens", () => ({
+  generateVerificationToken: vi.fn(),
+}));
+
+vi.mock("bcryptjs", () => ({
+  default: { hash: vi.fn(async () => "hashed-pw") },
+}));
+
+import { db } from "@/lib/db";
+import { getUserByEmail } from "@/data/user";
+import { sendVerificationEmail } from "@/lib/mail";
+import { generateVerificationToken } from "@/lib/tokens";
+import { register } from "./register";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("register", () => {
+  const validInput = {
+    email: "user@example.com",
+    password: "tenchars12",
+    name: "Taro",
+  };
+
+  it("returns error on invalid input", async () => {
+    const result = await register({ email: "bad", password: "short", name: "" });
+    expect(result).toEqual({ error: "入力に誤りがあります！" });
+    expect(getUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns error when email is already registered", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({ id: "u1" } as never);
+
+    const result = await register(validInput);
+
+    expect(result).toEqual({ error: "そのメールは既に使用されています！" });
+    expect(db.user.create).not.toHaveBeenCalled();
+  });
+
+  it("creates user, generates token, sends email, and returns success", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(null);
+    vi.mocked(generateVerificationToken).mockResolvedValue({
+      email: "user@example.com",
+      token: "vt",
+    } as never);
+
+    const result = await register(validInput);
+
+    expect(db.user.create).toHaveBeenCalledWith({
+      data: { name: "Taro", email: "user@example.com", password: "hashed-pw" },
+    });
+    expect(generateVerificationToken).toHaveBeenCalledWith("user@example.com");
+    expect(sendVerificationEmail).toHaveBeenCalledWith("user@example.com", "vt");
+    expect(result).toEqual({ success: "確認メールを送信しました！" });
+  });
+});

--- a/actions/reset.test.ts
+++ b/actions/reset.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/data/user", () => ({
+  getUserByEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/mail", () => ({
+  sendPasswordResetEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/tokens", () => ({
+  generatePasswordResetToken: vi.fn(),
+}));
+
+import { getUserByEmail } from "@/data/user";
+import { sendPasswordResetEmail } from "@/lib/mail";
+import { generatePasswordResetToken } from "@/lib/tokens";
+import { reset } from "./reset";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("reset", () => {
+  it("returns error on invalid email", async () => {
+    const result = await reset({ email: "not-an-email" });
+    expect(result).toEqual({ error: "正しくないメールアドレスです！" });
+    expect(getUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns error when user does not exist", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(null);
+
+    const result = await reset({ email: "missing@b.com" });
+
+    expect(result).toEqual({ error: "メールアドレスが見つかりません！" });
+    expect(sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it("generates reset token, sends email, and returns success", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({ id: "u1" } as never);
+    vi.mocked(generatePasswordResetToken).mockResolvedValue({
+      email: "a@b.com",
+      token: "prt",
+    } as never);
+
+    const result = await reset({ email: "a@b.com" });
+
+    expect(generatePasswordResetToken).toHaveBeenCalledWith("a@b.com");
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith("a@b.com", "prt");
+    expect(result).toEqual({ success: "再設定用のメールを送りました！" });
+  });
+});

--- a/app/(protected)/ems/categories/page.tsx
+++ b/app/(protected)/ems/categories/page.tsx
@@ -4,12 +4,7 @@ import React, { useState, useEffect, useTransition, useRef } from 'react';
 import { Button, Center, Spinner, Input } from '@chakra-ui/react';
 import Header from '@/app/(protected)/_components/Header';
 import axios from 'axios';
-
-interface Tags {
-    id: number;
-    name: string;
-    color: string;
-}
+import type { Tag as Tags } from "@/types/domain";
 
 const EditCategories = () => {
     const [isPending, startTransition] = useTransition();

--- a/app/(protected)/ems/edit/[equipmentId]/page.tsx
+++ b/app/(protected)/ems/edit/[equipmentId]/page.tsx
@@ -10,14 +10,9 @@ import type { PutBlobResult } from '@vercel/blob';
 import { Button } from '@chakra-ui/react';
 import Header from '@/app/(protected)/_components/Header';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { Tag as Tags } from "@/types/domain";
 
 const FIELD_SIZE = 210;
-
-interface Tags {
-  id: number;
-  name: string;
-  color: string;
-}
 
 const EditPage = () => {
   const params = useParams();

--- a/app/(protected)/ems/equipment-list/page.tsx
+++ b/app/(protected)/ems/equipment-list/page.tsx
@@ -9,22 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, Transition } from '@headlessui/react';
 import { CheckIcon } from '@heroicons/react/20/solid';
 import moment from 'moment-timezone';
-
-interface Equipment {
-    id: number;
-    name: string;
-    detail: string;
-    image: string;
-    tag_id: string;
-}
-
-interface Reserve {
-    id: number;
-    user_id: string;
-    start: string;
-    end: string;
-    list_id: number;
-}
+import type { Equipment, Reserve } from "@/types/domain";
 
 interface BulkReservation {
     start: string;

--- a/app/(protected)/ems/manager/page.tsx
+++ b/app/(protected)/ems/manager/page.tsx
@@ -9,18 +9,13 @@ import { useRouter } from "next/navigation";
 import { Button, Center, Spinner } from "@chakra-ui/react";
 import type { PutBlobResult } from "@vercel/blob";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { Equipment } from "@/types/domain";
 
 const IMAGE_ID = "imageId";
 const FIELD_SIZE = 210;
 
-interface Equipment {
-    id: number;
-    name: string;
-    detail: string;
-    image: string;
-    tag_id: string;
-}
-
+// TODO: API レスポンスは number だが、ここでは既存 UI 実装の都合で string として扱っている。
+// `@/types/domain` の Tag (id: number) との整合は別タスクで対応予定。
 interface Tags {
     id: string;
     name: string;

--- a/data/account.test.ts
+++ b/data/account.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: { account: { findFirst: vi.fn() } },
+}));
+
+import { db } from "@/lib/db";
+import { getAccountByUserId } from "./account";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getAccountByUserId", () => {
+  it("returns the account when found", async () => {
+    const account = { id: "acc1", userId: "u1", provider: "google" };
+    vi.mocked(db.account.findFirst).mockResolvedValue(account as never);
+
+    const result = await getAccountByUserId("u1");
+
+    expect(result).toEqual(account);
+    expect(db.account.findFirst).toHaveBeenCalledWith({ where: { userId: "u1" } });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.account.findFirst).mockRejectedValue(new Error("db down"));
+    expect(await getAccountByUserId("u1")).toBeNull();
+  });
+
+  it("returns null when account not found", async () => {
+    vi.mocked(db.account.findFirst).mockResolvedValue(null);
+    expect(await getAccountByUserId("u1")).toBeNull();
+  });
+});

--- a/data/password-reset-token.test.ts
+++ b/data/password-reset-token.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    passwordResetToken: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "@/lib/db";
+import {
+  getPasswordResetTokenByEmail,
+  getPasswordResetTokenByToken,
+} from "./password-reset-token";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getPasswordResetTokenByToken", () => {
+  it("returns token when found", async () => {
+    const t = { id: "t1", token: "abc", email: "a@b.com" };
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(t as never);
+
+    expect(await getPasswordResetTokenByToken("abc")).toEqual(t);
+    expect(db.passwordResetToken.findUnique).toHaveBeenCalledWith({
+      where: { token: "abc" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.passwordResetToken.findUnique).mockRejectedValue(new Error());
+    expect(await getPasswordResetTokenByToken("x")).toBeNull();
+  });
+});
+
+describe("getPasswordResetTokenByEmail", () => {
+  it("returns token when found", async () => {
+    const t = { id: "t1", token: "abc", email: "a@b.com" };
+    vi.mocked(db.passwordResetToken.findFirst).mockResolvedValue(t as never);
+
+    expect(await getPasswordResetTokenByEmail("a@b.com")).toEqual(t);
+    expect(db.passwordResetToken.findFirst).toHaveBeenCalledWith({
+      where: { email: "a@b.com" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.passwordResetToken.findFirst).mockRejectedValue(new Error());
+    expect(await getPasswordResetTokenByEmail("x")).toBeNull();
+  });
+});

--- a/data/two-factor-confirmation.test.ts
+++ b/data/two-factor-confirmation.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    twoFactorConfirmation: { findUnique: vi.fn() },
+  },
+}));
+
+import { db } from "@/lib/db";
+import { getTwoFactorConfirmationByUserId } from "./two-factor-confirmation";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getTwoFactorConfirmationByUserId", () => {
+  it("returns confirmation when found", async () => {
+    const c = { id: "c1", userId: "u1" };
+    vi.mocked(db.twoFactorConfirmation.findUnique).mockResolvedValue(c as never);
+
+    expect(await getTwoFactorConfirmationByUserId("u1")).toEqual(c);
+    expect(db.twoFactorConfirmation.findUnique).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.twoFactorConfirmation.findUnique).mockRejectedValue(new Error());
+    expect(await getTwoFactorConfirmationByUserId("u1")).toBeNull();
+  });
+});

--- a/data/two-factor-token.test.ts
+++ b/data/two-factor-token.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    twoFactorToken: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "@/lib/db";
+import {
+  getTwoFactorTokenByEmail,
+  getTwoFactorTokenByToken,
+} from "./two-factor-token";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getTwoFactorTokenByToken", () => {
+  it("returns token when found", async () => {
+    const t = { id: "t1", token: "123456", email: "a@b.com" };
+    vi.mocked(db.twoFactorToken.findUnique).mockResolvedValue(t as never);
+
+    expect(await getTwoFactorTokenByToken("123456")).toEqual(t);
+    expect(db.twoFactorToken.findUnique).toHaveBeenCalledWith({
+      where: { token: "123456" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.twoFactorToken.findUnique).mockRejectedValue(new Error());
+    expect(await getTwoFactorTokenByToken("x")).toBeNull();
+  });
+});
+
+describe("getTwoFactorTokenByEmail", () => {
+  it("returns token when found", async () => {
+    const t = { id: "t1", token: "123456", email: "a@b.com" };
+    vi.mocked(db.twoFactorToken.findFirst).mockResolvedValue(t as never);
+
+    expect(await getTwoFactorTokenByEmail("a@b.com")).toEqual(t);
+    expect(db.twoFactorToken.findFirst).toHaveBeenCalledWith({
+      where: { email: "a@b.com" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.twoFactorToken.findFirst).mockRejectedValue(new Error());
+    expect(await getTwoFactorTokenByEmail("x")).toBeNull();
+  });
+});

--- a/data/user.test.ts
+++ b/data/user.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "@/lib/db";
+import { getUserByEmail, getUserById } from "./user";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getUserByEmail", () => {
+  it("returns the user when found", async () => {
+    const user = { id: "1", email: "a@b.com" };
+    vi.mocked(db.user.findUnique).mockResolvedValue(user as never);
+
+    const result = await getUserByEmail("a@b.com");
+
+    expect(result).toEqual(user);
+    expect(db.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "a@b.com" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.user.findUnique).mockRejectedValue(new Error("db down"));
+
+    const result = await getUserByEmail("a@b.com");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user not found", async () => {
+    vi.mocked(db.user.findUnique).mockResolvedValue(null);
+
+    const result = await getUserByEmail("missing@b.com");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getUserById", () => {
+  it("returns the user when found", async () => {
+    const user = { id: "42", email: "x@y.com" };
+    vi.mocked(db.user.findUnique).mockResolvedValue(user as never);
+
+    const result = await getUserById("42");
+
+    expect(result).toEqual(user);
+    expect(db.user.findUnique).toHaveBeenCalledWith({ where: { id: "42" } });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.user.findUnique).mockRejectedValue(new Error("db down"));
+
+    const result = await getUserById("42");
+
+    expect(result).toBeNull();
+  });
+});

--- a/data/verification-token.test.ts
+++ b/data/verification-token.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    verificationToken: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "@/lib/db";
+import {
+  getVerificationTokenByEmail,
+  getVerificationTokenByToken,
+} from "./verification-token";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getVerificationTokenByToken", () => {
+  it("returns token when found", async () => {
+    const t = { id: "t1", token: "abc", email: "a@b.com" };
+    vi.mocked(db.verificationToken.findUnique).mockResolvedValue(t as never);
+
+    expect(await getVerificationTokenByToken("abc")).toEqual(t);
+    expect(db.verificationToken.findUnique).toHaveBeenCalledWith({
+      where: { token: "abc" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.verificationToken.findUnique).mockRejectedValue(new Error());
+    expect(await getVerificationTokenByToken("x")).toBeNull();
+  });
+});
+
+describe("getVerificationTokenByEmail", () => {
+  it("returns token when found", async () => {
+    const t = { id: "t1", token: "abc", email: "a@b.com" };
+    vi.mocked(db.verificationToken.findFirst).mockResolvedValue(t as never);
+
+    expect(await getVerificationTokenByEmail("a@b.com")).toEqual(t);
+    expect(db.verificationToken.findFirst).toHaveBeenCalledWith({
+      where: { email: "a@b.com" },
+    });
+  });
+
+  it("returns null when Prisma throws", async () => {
+    vi.mocked(db.verificationToken.findFirst).mockRejectedValue(new Error());
+    expect(await getVerificationTokenByEmail("x")).toBeNull();
+  });
+});

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -210,6 +210,42 @@ git branch -d hotfix/critical-bug
 git push origin --delete hotfix/critical-bug
 ```
 
+## テスト
+
+`schemas/`, `lib/`, `data/`, `actions/`, `hooks/` のピュアロジック層は Vitest でユニットテストを書く方針。
+
+### 実行コマンド
+
+```bash
+npm test            # 一度だけ実行（CI 用途）
+npm run test:watch  # ファイル変更を監視して再実行
+npm run test:ui     # ブラウザ UI で結果を確認
+```
+
+### 配置規約
+
+テストはソースの隣にコロケーションで置く（`*.test.ts`）。例:
+```
+schemas/index.ts
+schemas/index.test.ts
+actions/login.ts
+actions/login.test.ts
+```
+
+### モック方針
+
+- Prisma (`@/lib/db`): 各テストファイル先頭で `vi.mock` してメソッドを個別に stub
+- NextAuth (`@/auth`, `next-auth`): `signIn` や `AuthError` はモックで提供（実体を読み込むと `next/server` の解決に失敗する）
+- メール (`@/lib/mail`): `vi.fn()` で送信を no-op に
+- `next-auth/react` の `useSession`: hooks テストで `vi.mock` + `renderHook`
+
+詳細な例は [actions/login.test.ts](../actions/login.test.ts) を参照。
+
+### 何を書くか / 書かないか
+
+- ✅ **書く**: Zod スキーマのバリデーション分岐、Server Action の各エラーパス、Prisma を呼ぶ data 層、純粋関数
+- ⚠️ **後回し**: UI コンポーネント（Phase 2 以降で snapshot / interaction テストを追加予定）
+
 ## 補足
 
 - 詳細な背景・図解・研究向けケースは Notion の [Gitブランチ戦略ベストプラクティス](https://www.notion.so/d0c1aee52da245b1a33fb0b35e7a53f4) を参照

--- a/hooks/use-current-role.test.ts
+++ b/hooks/use-current-role.test.ts
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(),
+}));
+
+import { useSession } from "next-auth/react";
+import { useCurrentRole } from "./use-current-role";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("useCurrentRole", () => {
+  it("returns the role when session is present", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "u1", role: "ADMIN" } },
+      status: "authenticated",
+    } as never);
+
+    const { result } = renderHook(() => useCurrentRole());
+
+    expect(result.current).toBe("ADMIN");
+  });
+
+  it("returns undefined when session is null", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    } as never);
+
+    const { result } = renderHook(() => useCurrentRole());
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/hooks/use-current-user.test.ts
+++ b/hooks/use-current-user.test.ts
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(),
+}));
+
+import { useSession } from "next-auth/react";
+import { useCurrentUser } from "./use-current-user";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("useCurrentUser", () => {
+  it("returns the user when session is present", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: "u1", name: "Taro", role: "USER" } },
+      status: "authenticated",
+    } as never);
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current).toEqual({ id: "u1", name: "Taro", role: "USER" });
+  });
+
+  it("returns undefined when session is null", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    } as never);
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/lib/tokens.test.ts
+++ b/lib/tokens.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    verificationToken: { create: vi.fn(), delete: vi.fn() },
+    passwordResetToken: { create: vi.fn(), delete: vi.fn() },
+    twoFactorToken: { create: vi.fn(), delete: vi.fn() },
+  },
+}));
+
+vi.mock("@/data/verification-token", () => ({
+  getVerificationTokenByEmail: vi.fn(),
+}));
+vi.mock("@/data/password-reset-token", () => ({
+  getPasswordResetTokenByEmail: vi.fn(),
+}));
+vi.mock("@/data/two-factor-token", () => ({
+  getTwoFactorTokenByEmail: vi.fn(),
+}));
+
+vi.mock("uuid", () => ({
+  v4: vi.fn(() => "stub-uuid"),
+}));
+
+import { db } from "@/lib/db";
+import { getVerificationTokenByEmail } from "@/data/verification-token";
+import { getPasswordResetTokenByEmail } from "@/data/password-reset-token";
+import { getTwoFactorTokenByEmail } from "@/data/two-factor-token";
+import {
+  generatePasswordResetToken,
+  generateTwoFactorToken,
+  generateVerificationToken,
+} from "./tokens";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("generateVerificationToken", () => {
+  it("creates a new token with uuid and 1-hour expiry when none exists", async () => {
+    vi.mocked(getVerificationTokenByEmail).mockResolvedValue(null);
+    const created = { id: "new1", email: "a@b.com", token: "stub-uuid", expires: new Date() };
+    vi.mocked(db.verificationToken.create).mockResolvedValue(created as never);
+
+    const result = await generateVerificationToken("a@b.com");
+
+    expect(db.verificationToken.delete).not.toHaveBeenCalled();
+    expect(db.verificationToken.create).toHaveBeenCalledOnce();
+    const callArgs = vi.mocked(db.verificationToken.create).mock.calls[0]?.[0];
+    expect(callArgs?.data.email).toBe("a@b.com");
+    expect(callArgs?.data.token).toBe("stub-uuid");
+    expect(result).toEqual(created);
+  });
+
+  it("deletes existing token before creating a new one", async () => {
+    vi.mocked(getVerificationTokenByEmail).mockResolvedValue({
+      id: "old",
+      email: "a@b.com",
+      token: "prev",
+      expires: new Date(),
+    } as never);
+    vi.mocked(db.verificationToken.create).mockResolvedValue({} as never);
+
+    await generateVerificationToken("a@b.com");
+
+    expect(db.verificationToken.delete).toHaveBeenCalledWith({ where: { id: "old" } });
+    expect(db.verificationToken.create).toHaveBeenCalledOnce();
+  });
+
+  it("sets expiry roughly 1 hour in the future", async () => {
+    vi.mocked(getVerificationTokenByEmail).mockResolvedValue(null);
+    vi.mocked(db.verificationToken.create).mockResolvedValue({} as never);
+
+    const before = Date.now();
+    await generateVerificationToken("a@b.com");
+    const after = Date.now();
+
+    const callArgs = vi.mocked(db.verificationToken.create).mock.calls[0]?.[0];
+    const expires = callArgs?.data.expires as Date;
+    expect(expires.getTime()).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    expect(expires.getTime()).toBeLessThanOrEqual(after + 3600 * 1000);
+  });
+});
+
+describe("generatePasswordResetToken", () => {
+  it("creates a new token when none exists", async () => {
+    vi.mocked(getPasswordResetTokenByEmail).mockResolvedValue(null);
+    const created = { id: "new1", email: "a@b.com", token: "stub-uuid", expires: new Date() };
+    vi.mocked(db.passwordResetToken.create).mockResolvedValue(created as never);
+
+    const result = await generatePasswordResetToken("a@b.com");
+
+    expect(db.passwordResetToken.delete).not.toHaveBeenCalled();
+    expect(result).toEqual(created);
+  });
+
+  it("deletes existing token before creating a new one", async () => {
+    vi.mocked(getPasswordResetTokenByEmail).mockResolvedValue({
+      id: "old",
+      email: "a@b.com",
+      token: "prev",
+      expires: new Date(),
+    } as never);
+    vi.mocked(db.passwordResetToken.create).mockResolvedValue({} as never);
+
+    await generatePasswordResetToken("a@b.com");
+
+    expect(db.passwordResetToken.delete).toHaveBeenCalledWith({ where: { id: "old" } });
+  });
+});
+
+describe("generateTwoFactorToken", () => {
+  it("creates a 6-digit numeric token when none exists", async () => {
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue(null);
+    vi.mocked(db.twoFactorToken.create).mockResolvedValue({} as never);
+
+    await generateTwoFactorToken("a@b.com");
+
+    expect(db.twoFactorToken.delete).not.toHaveBeenCalled();
+    const callArgs = vi.mocked(db.twoFactorToken.create).mock.calls[0]?.[0];
+    const token = callArgs?.data.token as string;
+    expect(token).toMatch(/^\d{6}$/);
+  });
+
+  it("deletes existing token before creating a new one", async () => {
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue({
+      id: "old",
+      email: "a@b.com",
+      token: "111111",
+      expires: new Date(),
+    } as never);
+    vi.mocked(db.twoFactorToken.create).mockResolvedValue({} as never);
+
+    await generateTwoFactorToken("a@b.com");
+
+    expect(db.twoFactorToken.delete).toHaveBeenCalledWith({ where: { id: "old" } });
+  });
+
+  it("sets expiry roughly 5 minutes in the future", async () => {
+    vi.mocked(getTwoFactorTokenByEmail).mockResolvedValue(null);
+    vi.mocked(db.twoFactorToken.create).mockResolvedValue({} as never);
+
+    const before = Date.now();
+    await generateTwoFactorToken("a@b.com");
+    const after = Date.now();
+
+    const callArgs = vi.mocked(db.twoFactorToken.create).mock.calls[0]?.[0];
+    const expires = callArgs?.data.expires as Date;
+    expect(expires.getTime()).toBeGreaterThanOrEqual(before + 5 * 60 * 1000);
+    expect(expires.getTime()).toBeLessThanOrEqual(after + 5 * 60 * 1000);
+  });
+});

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("merges plain class names", () => {
+    expect(cn("a", "b")).toBe("a b");
+  });
+
+  it("filters falsy values", () => {
+    expect(cn("a", false, null, undefined, "b")).toBe("a b");
+  });
+
+  it("supports conditional classes via objects", () => {
+    expect(cn("a", { b: true, c: false })).toBe("a b");
+  });
+
+  it("dedupes conflicting Tailwind classes (last wins)", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4");
+  });
+
+  it("preserves non-conflicting Tailwind classes", () => {
+    expect(cn("text-sm", "font-bold")).toBe("text-sm font-bold");
+  });
+
+  it("returns empty string when no inputs", () => {
+    expect(cn()).toBe("");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,19 +60,33 @@
         "zod": "^3.23.4"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/bcrypt": "^5.0.2",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/uuid": "^9.0.8",
+        "@vitest/ui": "^4.1.6",
         "eslint": "^8",
         "eslint-config-next": "14.2.2",
+        "happy-dom": "^20.9.0",
         "postcss": "^8",
         "prisma": "^5.13.0",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1606,6 +1620,40 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -2111,9 +2159,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2141,6 +2190,25 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@neondatabase/serverless": {
@@ -2356,6 +2424,16 @@
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -2372,6 +2450,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -3270,6 +3355,270 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3368,6 +3717,13 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -3417,6 +3773,164 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/bcrypt": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
@@ -3432,10 +3946,28 @@
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
       "dev": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -3460,8 +3992,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "peer": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -3502,11 +4033,12 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -3573,6 +4105,23 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "7.2.0",
@@ -3754,6 +4303,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.6.tgz",
+      "integrity": "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.6"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -4290,6 +5011,16 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4668,6 +5399,16 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4957,6 +5698,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5009,6 +5759,13 @@
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/css/node_modules/source-map": {
       "version": "0.6.1",
@@ -5256,6 +6013,17 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-file": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
@@ -5313,6 +6081,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -6187,6 +6963,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -6276,6 +7062,13 @@
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.30"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -6485,10 +7278,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/focus-lock": {
       "version": "1.3.5",
@@ -7027,6 +7821,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7048,6 +7849,37 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -7242,6 +8074,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -8161,6 +9003,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -8262,6 +9365,17 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -8367,6 +9481,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -8464,6 +9588,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.13.0.tgz",
       "integrity": "sha512-lq6TzXkH5c/ysJQBxgLXgM01qwBH1b4goTPh57VvZWJbVJZF/0SB31UWEn4EIqbVPf3au88n2rvK17SpDTja1A=="
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8480,15 +9614,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -8907,6 +10042,17 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9134,6 +10280,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/peberminta": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
@@ -9299,9 +10452,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -9316,8 +10469,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9391,17 +10545,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/postcss-nested": {
@@ -9958,6 +11101,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.7.tgz",
@@ -10214,6 +11371,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/rollup": {
@@ -10473,6 +11664,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10482,6 +11680,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/slash": {
@@ -10571,6 +11784,20 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
       "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -10794,6 +12021,19 @@
       "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -11202,10 +12442,85 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -11222,6 +12537,16 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -11244,6 +12569,27 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -11437,9 +12783,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -11607,6 +12954,232 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
@@ -11725,6 +13298,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -11830,6 +13413,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -12261,6 +13861,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12276,11 +13898,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
     "postinstall": "prisma generate"
   },
   "dependencies": {
@@ -61,17 +64,24 @@
     "zod": "^3.23.4"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bcrypt": "^5.0.2",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/uuid": "^9.0.8",
+    "@vitest/ui": "^4.1.6",
     "eslint": "^8",
     "eslint-config-next": "14.2.2",
+    "happy-dom": "^20.9.0",
     "postcss": "^8",
     "prisma": "^5.13.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.6"
   }
 }

--- a/schemas/index.test.ts
+++ b/schemas/index.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  LoginSchema,
+  NewPasswordSchema,
+  RegisterSchema,
+  ResetSchema,
+  SettingsSchema,
+} from "./index";
+
+describe("LoginSchema", () => {
+  it("accepts valid email + password", () => {
+    const result = LoginSchema.safeParse({
+      email: "user@example.com",
+      password: "anything",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional 2FA code", () => {
+    const result = LoginSchema.safeParse({
+      email: "user@example.com",
+      password: "anything",
+      code: "123456",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid email format", () => {
+    const result = LoginSchema.safeParse({
+      email: "not-an-email",
+      password: "anything",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty password", () => {
+    const result = LoginSchema.safeParse({
+      email: "user@example.com",
+      password: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("RegisterSchema", () => {
+  it("accepts valid input", () => {
+    const result = RegisterSchema.safeParse({
+      email: "user@example.com",
+      password: "tenchars12",
+      name: "Taro",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects password shorter than 10 chars", () => {
+    const result = RegisterSchema.safeParse({
+      email: "user@example.com",
+      password: "short",
+      name: "Taro",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty name", () => {
+    const result = RegisterSchema.safeParse({
+      email: "user@example.com",
+      password: "tenchars12",
+      name: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid email format", () => {
+    const result = RegisterSchema.safeParse({
+      email: "no-at-sign",
+      password: "tenchars12",
+      name: "Taro",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ResetSchema", () => {
+  it("accepts valid email", () => {
+    const result = ResetSchema.safeParse({ email: "user@example.com" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid email", () => {
+    const result = ResetSchema.safeParse({ email: "no-at-sign" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("NewPasswordSchema", () => {
+  it("accepts password >= 10 chars", () => {
+    const result = NewPasswordSchema.safeParse({ password: "tenchars12" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects password < 10 chars", () => {
+    const result = NewPasswordSchema.safeParse({ password: "short" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("SettingsSchema", () => {
+  it("accepts role-only update", () => {
+    const result = SettingsSchema.safeParse({ role: "USER" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts ADMIN role", () => {
+    const result = SettingsSchema.safeParse({ role: "ADMIN" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts both password and newPassword together", () => {
+    const result = SettingsSchema.safeParse({
+      role: "USER",
+      password: "currentpass",
+      newPassword: "newpass1234",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects password without newPassword", () => {
+    const result = SettingsSchema.safeParse({
+      role: "USER",
+      password: "currentpass",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["newPassword"]);
+    }
+  });
+
+  it("rejects newPassword without password", () => {
+    const result = SettingsSchema.safeParse({
+      role: "USER",
+      newPassword: "newpass1234",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["password"]);
+    }
+  });
+
+  it("accepts optional name and email", () => {
+    const result = SettingsSchema.safeParse({
+      role: "USER",
+      name: "Taro",
+      email: "user@example.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid email format", () => {
+    const result = SettingsSchema.safeParse({
+      role: "USER",
+      email: "not-an-email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects role outside enum", () => {
+    const result = SettingsSchema.safeParse({ role: "GUEST" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects newPassword shorter than 10 chars", () => {
+    const result = SettingsSchema.safeParse({
+      role: "USER",
+      password: "currentpass",
+      newPassword: "short",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,6 @@
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+vi.stubEnv("AUTH_SECRET", "test-secret");
+vi.stubEnv("RESEND_API_KEY", "test-resend-key");
+vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3000");

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -1,0 +1,27 @@
+/**
+ * UI 層で使用されるドメイン型の集約。
+ * Prisma 生成型と完全一致しない箇所は、API レスポンスや既存 UI 実装に合わせた形で定義している。
+ * 真の正規化は API 層リファクタの段階で実施する予定。
+ */
+
+export interface Equipment {
+  id: number;
+  name: string;
+  detail: string;
+  image: string;
+  tag_id: string;
+}
+
+export interface Tag {
+  id: number;
+  name: string;
+  color: string;
+}
+
+export interface Reserve {
+  id: number;
+  user_id: string;
+  start: string;
+  end: string;
+  list_id: number;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    setupFiles: ["./test/setup.ts"],
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    exclude: ["node_modules", ".next", "dist"],
+  },
+});


### PR DESCRIPTION
## Summary
Phase 1 リファクタリング: ピュアロジック層にユニットテスト 90 件を追加し、UI 層の重複型を集約。**動作変更ゼロ**。

## 追加
- **Vitest + Testing Library + happy-dom** セットアップ
- **16 テストファイル / 90 テスト** すべて pass
  - \`schemas/\` 21 件 — 5 つの Zod スキーマ × バリデーション分岐
  - \`lib/utils\`, \`lib/tokens\` 15 件
  - \`data/\` 6 ファイル / 16 件 — Prisma 呼び出しのエラーパス含む
  - \`actions/\` 5 ファイル / 30 件 — login の 2FA フロー全分岐含む
  - \`hooks/\` 2 ファイル / 4 件 — useSession モック
- \`types/domain.ts\` — Equipment / Tag / Reserve の正規化定義
- npm scripts: \`test\` / \`test:watch\` / \`test:ui\`

## 修正（型重複除去）
4 箇所の重複インターフェイスを \`types/domain.ts\` の import に置換:
- \`app/(protected)/ems/manager/page.tsx\` — Equipment
- \`app/(protected)/ems/equipment-list/page.tsx\` — Equipment + Reserve
- \`app/(protected)/ems/edit/[equipmentId]/page.tsx\` — Tag
- \`app/(protected)/ems/categories/page.tsx\` — Tag

manager の \`Tags\`（id: string）は他 2 箇所（id: number）と型不整合があるため、TODO コメント付きで局所維持。Phase 2 で API 層と一緒に整合させる予定。

## 動作変更ゼロの担保
- テストは新規追加のみ、既存コードに副作用なし
- 型集約は TS の型レベル変更のみ — コンパイル後の JS は完全に同一
- UI ファイルの変更は **型 import の差し替えのみ**（JSX / hooks / state には触れていない）
- \`npm test\` 90/90 pass / \`npm run lint\` 既存警告のみ / \`npm run build\` 成功

## Test plan
- [ ] Vercel Preview デプロイが緑
- [ ] ログイン → マイページ → 機材一覧 → 予約 → 管理者画面を 1 周し挙動変化なし
- [ ] \`npm test\` を CI 相当でローカル実行できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)