### PR TITLE
refactor: extract custom hooks from equipment-list page

### DIFF
--- a/app/(protected)/ems/equipment-list/hooks/use-bulk-reservation.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-bulk-reservation.test.ts
@@ -1,0 +1,277 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: { post: vi.fn() },
+}));
+
+import axios from "axios";
+import type { Equipment, Reserve } from "@/types/domain";
+import { useBulkReservation } from "./use-bulk-reservation";
+
+const makeEquipment = (partial: Partial<Equipment>): Equipment => ({
+  id: 1,
+  name: "Camera",
+  detail: "",
+  image: "",
+  tag_id: "1",
+  ...partial,
+});
+
+const makeReserve = (partial: Partial<Reserve>): Reserve => ({
+  id: 1,
+  user_id: "u1",
+  start: "2026-01-01",
+  end: "2026-01-02",
+  list_id: 1,
+  ...partial,
+});
+
+const fakeFormEvent = () =>
+  ({ preventDefault: vi.fn() }) as unknown as React.FormEvent<HTMLFormElement>;
+
+const refetchReserves = vi.fn(async () => {});
+const alertMock = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+const defaultParams = {
+  userId: "u1",
+  equipments: [
+    makeEquipment({ id: 1, name: "Camera" }),
+    makeEquipment({ id: 2, name: "Tripod" }),
+  ],
+  reserves: [] as Reserve[],
+  refetchReserves,
+};
+
+const futureStart = () =>
+  new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString().slice(0, 10);
+const futureEnd = () =>
+  new Date(Date.now() + 1000 * 60 * 60 * 24 * 14).toISOString().slice(0, 10);
+
+beforeEach(() => {
+  vi.mocked(axios.post).mockReset();
+  refetchReserves.mockClear();
+  alertMock.mockReset();
+  consoleErrorSpy.mockClear();
+  vi.stubGlobal("alert", alertMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("useBulkReservation - mode + selection", () => {
+  it("toggles bulk mode and clears selection", () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+    });
+    expect(result.current.selectedIds.has(1)).toBe(true);
+
+    act(() => {
+      result.current.toggleBulkMode();
+    });
+    expect(result.current.isBulkMode).toBe(true);
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it("toggleEquipment adds and removes IDs", () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+      result.current.toggleEquipment(2, true);
+    });
+    expect(Array.from(result.current.selectedIds).sort()).toEqual([1, 2]);
+
+    act(() => {
+      result.current.toggleEquipment(1, false);
+    });
+    expect(Array.from(result.current.selectedIds)).toEqual([2]);
+  });
+});
+
+describe("useBulkReservation - modal control", () => {
+  it("alerts when no equipment is selected", async () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    await act(async () => {
+      await result.current.openModal();
+    });
+
+    expect(alertMock).toHaveBeenCalledWith("少なくとも1つの機材を選択してください。");
+    expect(result.current.showModal).toBe(false);
+    expect(refetchReserves).not.toHaveBeenCalled();
+  });
+
+  it("opens modal and refetches reserves when selection exists", async () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+    });
+
+    await act(async () => {
+      await result.current.openModal();
+    });
+
+    expect(refetchReserves).toHaveBeenCalledOnce();
+    expect(result.current.showModal).toBe(true);
+  });
+
+  it("closeModal hides modal and resets form", () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.updateForm({ start: "2026-01-01", end: "2026-01-02" });
+    });
+    act(() => {
+      result.current.closeModal();
+    });
+
+    expect(result.current.showModal).toBe(false);
+    expect(result.current.bulkForm).toEqual({ start: "", end: "" });
+  });
+});
+
+describe("useBulkReservation - submit validation", () => {
+  it("alerts when date fields are empty", async () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+    });
+
+    await act(async () => {
+      await result.current.submit(fakeFormEvent());
+    });
+
+    expect(alertMock).toHaveBeenCalledWith("開始日と終了日を選択してください。");
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it("alerts on past dates", async () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+      result.current.updateForm({ start: "2020-01-01", end: "2020-01-02" });
+    });
+
+    await act(async () => {
+      await result.current.submit(fakeFormEvent());
+    });
+
+    expect(alertMock).toHaveBeenCalledWith(
+      "無効な予約日です。開始日は今日以降、終了日は開始日以降を選択してください。",
+    );
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it("alerts when end < start", async () => {
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+      result.current.updateForm({ start: futureEnd(), end: futureStart() });
+    });
+
+    await act(async () => {
+      await result.current.submit(fakeFormEvent());
+    });
+
+    expect(alertMock).toHaveBeenCalledWith(
+      "無効な予約日です。開始日は今日以降、終了日は開始日以降を選択してください。",
+    );
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it("alerts when there is an overlap and lists conflicting names", async () => {
+    const start = futureStart();
+    const end = futureEnd();
+
+    const { result } = renderHook(() =>
+      useBulkReservation({
+        ...defaultParams,
+        reserves: [makeReserve({ list_id: 1, start, end })],
+      }),
+    );
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+      result.current.updateForm({ start, end });
+    });
+
+    await act(async () => {
+      await result.current.submit(fakeFormEvent());
+    });
+
+    expect(alertMock.mock.calls[0]?.[0]).toContain("Camera");
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});
+
+describe("useBulkReservation - submit success path", () => {
+  it("posts once per selected equipment, alerts, and resets state", async () => {
+    vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
+
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    const start = futureStart();
+    const end = futureEnd();
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+      result.current.toggleEquipment(2, true);
+      result.current.updateForm({ start, end });
+    });
+
+    await act(async () => {
+      await result.current.submit(fakeFormEvent());
+    });
+
+    expect(axios.post).toHaveBeenCalledTimes(2);
+    expect(axios.post).toHaveBeenCalledWith("/api/reserves", {
+      user_id: "u1",
+      start,
+      end,
+      list_id: 1,
+    });
+    expect(axios.post).toHaveBeenCalledWith("/api/reserves", {
+      user_id: "u1",
+      start,
+      end,
+      list_id: 2,
+    });
+
+    await waitFor(() => expect(result.current.isSubmitting).toBe(false));
+
+    expect(alertMock).toHaveBeenCalledWith("2件の予約が正常に完了しました。");
+    expect(result.current.showModal).toBe(false);
+    expect(result.current.bulkForm).toEqual({ start: "", end: "" });
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.isBulkMode).toBe(false);
+  });
+
+  it("alerts on POST failure and clears isSubmitting", async () => {
+    vi.mocked(axios.post).mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useBulkReservation(defaultParams));
+
+    act(() => {
+      result.current.toggleEquipment(1, true);
+      result.current.updateForm({ start: futureStart(), end: futureEnd() });
+    });
+
+    await act(async () => {
+      await result.current.submit(fakeFormEvent());
+    });
+
+    expect(alertMock).toHaveBeenCalledWith("予約の作成中にエラーが発生しました。");
+    expect(result.current.isSubmitting).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/app/(protected)/ems/equipment-list/hooks/use-bulk-reservation.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-bulk-reservation.ts
@@ -1,0 +1,143 @@
+"use client";
+
+import axios from "axios";
+import moment from "moment-timezone";
+import { useState } from "react";
+
+import { checkAllOverlaps } from "@/lib/reservation-overlap";
+import type { Equipment, Reserve } from "@/types/domain";
+
+export interface BulkForm {
+  start: string;
+  end: string;
+}
+
+export interface UseBulkReservationParams {
+  userId: string | undefined;
+  equipments: Equipment[];
+  reserves: Reserve[];
+  refetchReserves: () => Promise<void>;
+}
+
+export const useBulkReservation = ({
+  userId,
+  equipments,
+  reserves,
+  refetchReserves,
+}: UseBulkReservationParams) => {
+  const [isBulkMode, setIsBulkMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [showModal, setShowModal] = useState(false);
+  const [bulkForm, setBulkForm] = useState<BulkForm>({ start: "", end: "" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const toggleBulkMode = () => {
+    setIsBulkMode((prev) => !prev);
+    setSelectedIds(new Set());
+  };
+
+  const toggleEquipment = (equipmentId: number, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(equipmentId);
+      } else {
+        next.delete(equipmentId);
+      }
+      return next;
+    });
+  };
+
+  const openModal = async () => {
+    if (selectedIds.size === 0) {
+      alert("少なくとも1つの機材を選択してください。");
+      return;
+    }
+    await refetchReserves();
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+    setBulkForm({ start: "", end: "" });
+  };
+
+  const updateForm = (partial: Partial<BulkForm>) => {
+    setBulkForm((prev) => ({ ...prev, ...partial }));
+  };
+
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (bulkForm.start === "" || bulkForm.end === "") {
+      alert("開始日と終了日を選択してください。");
+      return;
+    }
+
+    const today = moment().tz("Asia/Tokyo").format("YYYY-MM-DD");
+    const start = moment(bulkForm.start).tz("Asia/Tokyo").format("YYYY-MM-DD");
+    const end = moment(bulkForm.end).tz("Asia/Tokyo").format("YYYY-MM-DD");
+
+    if (start < today || end < today || end < start) {
+      alert("無効な予約日です。開始日は今日以降、終了日は開始日以降を選択してください。");
+      return;
+    }
+
+    const { hasOverlap, conflictingEquipments } = checkAllOverlaps(
+      reserves,
+      equipments,
+      selectedIds,
+      bulkForm.start,
+      bulkForm.end,
+    );
+
+    if (hasOverlap) {
+      alert(
+        `以下の機材は選択した期間に既に予約が入っています：\n${conflictingEquipments.join("\n")}\n\n別の期間を選択してください。`,
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const ids = Array.from(selectedIds);
+      const promises = ids.map((listId) =>
+        axios.post("/api/reserves", {
+          user_id: userId,
+          start: bulkForm.start,
+          end: bulkForm.end,
+          list_id: listId,
+        }),
+      );
+
+      await Promise.all(promises);
+
+      alert(`${ids.length}件の予約が正常に完了しました。`);
+
+      setShowModal(false);
+      setBulkForm({ start: "", end: "" });
+      setSelectedIds(new Set());
+      setIsBulkMode(false);
+    } catch (error) {
+      console.error("Error creating bulk reservations:", error);
+      alert("予約の作成中にエラーが発生しました。");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    isBulkMode,
+    selectedIds,
+    bulkForm,
+    showModal,
+    isSubmitting,
+    toggleBulkMode,
+    toggleEquipment,
+    openModal,
+    closeModal,
+    updateForm,
+    submit,
+  };
+};

--- a/app/(protected)/ems/equipment-list/hooks/use-categories.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-categories.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCategories } from "./use-categories";
+
+const fetchMock = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+  consoleErrorSpy.mockClear();
+});
+
+describe("useCategories", () => {
+  it("starts with empty categories and isLoading=true", () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+    const { result } = renderHook(() => useCategories());
+    expect(result.current.categories).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("fetches /api/tags on mount and stores result", async () => {
+    fetchMock.mockResolvedValue({
+      json: async () => [
+        { id: "1", name: "Audio", color: "#ff0000" },
+        { id: "2", name: "Video", color: "#00ff00" },
+      ],
+    });
+
+    const { result } = renderHook(() => useCategories());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/tags");
+    expect(result.current.categories).toHaveLength(2);
+    expect(result.current.categories[0].name).toBe("Audio");
+  });
+
+  it("handles fetch errors gracefully and clears loading", async () => {
+    fetchMock.mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useCategories());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.categories).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/app/(protected)/ems/equipment-list/hooks/use-categories.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-categories.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// equipment-list ページでは category.id を Select の value（string 必須）に直接渡しているため、
+// ここでは string として扱う。`@/types/domain` の Tag (id: number) との整合は別タスクで対応予定。
+export interface Category {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export const useCategories = () => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const refetch = async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/tags");
+      const data = await response.json();
+      setCategories(data);
+    } catch (error) {
+      console.error("Error fetching categories: ", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refetch();
+  }, []);
+
+  return { categories, isLoading, refetch };
+};

--- a/app/(protected)/ems/equipment-list/hooks/use-equipments.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-equipments.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useEquipments } from "./use-equipments";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+describe("useEquipments", () => {
+  it("starts with empty equipments and isLoading=true", () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+    const { result } = renderHook(() => useEquipments());
+    expect(result.current.equipments).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("fetches /api/lists on mount and sorts by name", async () => {
+    fetchMock.mockResolvedValue({
+      json: async () => [
+        { id: 1, name: "Tripod", detail: "", image: "", tag_id: "1" },
+        { id: 2, name: "Camera", detail: "", image: "", tag_id: "1" },
+        { id: 3, name: "Mic", detail: "", image: "", tag_id: "1" },
+      ],
+    });
+
+    const { result } = renderHook(() => useEquipments());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/lists");
+    expect(result.current.equipments.map((e) => e.name)).toEqual(["Camera", "Mic", "Tripod"]);
+  });
+
+  it("refetch re-runs the fetch", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    const { result } = renderHook(() => useEquipments());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    fetchMock.mockClear();
+    await result.current.refetch();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/lists");
+  });
+});

--- a/app/(protected)/ems/equipment-list/hooks/use-equipments.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-equipments.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Equipment } from "@/types/domain";
+
+export const useEquipments = () => {
+  const [equipments, setEquipments] = useState<Equipment[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const refetch = async () => {
+    const response = await fetch("/api/lists");
+    const data: Equipment[] = await response.json();
+    const sortedData = data.sort((a, b) => a.name.localeCompare(b.name));
+    setEquipments(sortedData);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    refetch();
+  }, []);
+
+  return { equipments, isLoading, refetch };
+};

--- a/app/(protected)/ems/equipment-list/hooks/use-reservation-navigation.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reservation-navigation.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+import { useReservationNavigation } from "./use-reservation-navigation";
+
+beforeEach(() => {
+  pushMock.mockReset();
+});
+
+describe("useReservationNavigation", () => {
+  it("starts with loadingId=null", () => {
+    const { result } = renderHook(() => useReservationNavigation());
+    expect(result.current.loadingId).toBeNull();
+  });
+
+  it("sets loadingId and calls router.push with the equipment id", () => {
+    const { result } = renderHook(() => useReservationNavigation());
+
+    act(() => {
+      result.current.navigateToReserve(42);
+    });
+
+    expect(result.current.loadingId).toBe(42);
+    expect(pushMock).toHaveBeenCalledWith("/ems/reserve/42");
+  });
+
+  it("tracks the most recent navigation id", () => {
+    const { result } = renderHook(() => useReservationNavigation());
+
+    act(() => {
+      result.current.navigateToReserve(1);
+    });
+    act(() => {
+      result.current.navigateToReserve(2);
+    });
+
+    expect(result.current.loadingId).toBe(2);
+    expect(pushMock).toHaveBeenNthCalledWith(1, "/ems/reserve/1");
+    expect(pushMock).toHaveBeenNthCalledWith(2, "/ems/reserve/2");
+  });
+});

--- a/app/(protected)/ems/equipment-list/hooks/use-reservation-navigation.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reservation-navigation.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+export const useReservationNavigation = () => {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [loadingId, setLoadingId] = useState<number | null>(null);
+
+  const navigateToReserve = (id: number) => {
+    setLoadingId(id);
+    startTransition(() => {
+      router.push("/ems/reserve/" + id);
+    });
+  };
+
+  return { loadingId, isPending, navigateToReserve };
+};

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useReserves } from "./use-reserves";
+
+const fetchMock = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+  consoleErrorSpy.mockClear();
+});
+
+describe("useReserves", () => {
+  it("starts with empty reserves", () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+    const { result } = renderHook(() => useReserves());
+    expect(result.current.reserves).toEqual([]);
+  });
+
+  it("fetches /api/reserves on mount and stores result", async () => {
+    const data = [
+      { id: 1, user_id: "u1", start: "2026-01-01", end: "2026-01-02", list_id: 1 },
+    ];
+    fetchMock.mockResolvedValue({ json: async () => data });
+
+    const { result } = renderHook(() => useReserves());
+
+    await waitFor(() => expect(result.current.reserves).toHaveLength(1));
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/reserves");
+    expect(result.current.reserves).toEqual(data);
+  });
+
+  it("logs and continues when fetch fails", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useReserves());
+
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+
+    expect(result.current.reserves).toEqual([]);
+  });
+
+  it("refetch re-runs the fetch", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    const { result } = renderHook(() => useReserves());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await result.current.refetch();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Reserve } from "@/types/domain";
+
+export const useReserves = () => {
+  const [reserves, setReserves] = useState<Reserve[]>([]);
+
+  const refetch = async () => {
+    try {
+      const response = await fetch("/api/reserves");
+      const data: Reserve[] = await response.json();
+      setReserves(data);
+    } catch (error) {
+      console.error("Error fetching reserves:", error);
+    }
+  };
+
+  useEffect(() => {
+    refetch();
+  }, []);
+
+  return { reserves, refetch };
+};

--- a/app/(protected)/ems/equipment-list/page.test.tsx
+++ b/app/(protected)/ems/equipment-list/page.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-current-user", () => ({
+  useCurrentUser: () => ({ id: "u1", name: "Taro" }),
+}));
+
+vi.mock("@/app/(protected)/_components/Header", () => ({
+  default: () => null,
+}));
+
+vi.mock("./hooks/use-equipments", () => ({ useEquipments: vi.fn() }));
+vi.mock("./hooks/use-categories", () => ({ useCategories: vi.fn() }));
+vi.mock("./hooks/use-reserves", () => ({ useReserves: vi.fn() }));
+vi.mock("./hooks/use-reservation-navigation", () => ({
+  useReservationNavigation: vi.fn(),
+}));
+vi.mock("./hooks/use-bulk-reservation", () => ({
+  useBulkReservation: vi.fn(),
+}));
+
+import { useEquipments } from "./hooks/use-equipments";
+import { useCategories } from "./hooks/use-categories";
+import { useReserves } from "./hooks/use-reserves";
+import { useReservationNavigation } from "./hooks/use-reservation-navigation";
+import { useBulkReservation } from "./hooks/use-bulk-reservation";
+import EquipmentList from "./page";
+
+const defaultBulk = {
+  isBulkMode: false,
+  selectedIds: new Set<number>(),
+  bulkForm: { start: "", end: "" },
+  showModal: false,
+  isSubmitting: false,
+  toggleBulkMode: vi.fn(),
+  toggleEquipment: vi.fn(),
+  openModal: vi.fn(),
+  closeModal: vi.fn(),
+  updateForm: vi.fn(),
+  submit: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.mocked(useCategories).mockReturnValue({
+    categories: [],
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  vi.mocked(useReserves).mockReturnValue({ reserves: [], refetch: vi.fn() });
+  vi.mocked(useReservationNavigation).mockReturnValue({
+    loadingId: null,
+    isPending: false,
+    navigateToReserve: vi.fn(),
+  });
+  vi.mocked(useBulkReservation).mockReturnValue(defaultBulk);
+});
+
+describe("EquipmentList page", () => {
+  it("shows the loading spinner while equipments are loading", () => {
+    vi.mocked(useEquipments).mockReturnValue({
+      equipments: [],
+      isLoading: true,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<EquipmentList />);
+
+    // Chakra Spinner renders with role="status"
+    expect(container.querySelector('[class*="chakra-spinner"]')).not.toBeNull();
+  });
+
+  it("renders equipment names after loading", () => {
+    vi.mocked(useEquipments).mockReturnValue({
+      equipments: [
+        { id: 1, name: "Camera", detail: "", image: "", tag_id: "1" },
+        { id: 2, name: "Tripod", detail: "", image: "", tag_id: "1" },
+      ],
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    render(<EquipmentList />);
+
+    expect(screen.getByText("Camera")).toBeInTheDocument();
+    expect(screen.getByText("Tripod")).toBeInTheDocument();
+  });
+
+  it("shows empty-state message when no equipments match the filter", () => {
+    vi.mocked(useEquipments).mockReturnValue({
+      equipments: [],
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    render(<EquipmentList />);
+
+    expect(screen.getByText("該当する機材が見つかりませんでした。")).toBeInTheDocument();
+  });
+});

--- a/app/(protected)/ems/equipment-list/page.tsx
+++ b/app/(protected)/ems/equipment-list/page.tsx
@@ -1,264 +1,38 @@
 "use client"
-import React, { Fragment, useEffect, useState, useTransition } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { Fragment, useState } from 'react';
 import Header from '@/app/(protected)/_components/Header';
 import { useCurrentUser } from '@/hooks/use-current-user';
-import axios from 'axios';
 import { Button, Center, Spinner } from '@chakra-ui/react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, Transition } from '@headlessui/react';
 import { CheckIcon } from '@heroicons/react/20/solid';
-import moment from 'moment-timezone';
-import type { Equipment, Reserve } from "@/types/domain";
-
-interface BulkReservation {
-    start: string;
-    end: string;
-}
+import { useEquipments } from './hooks/use-equipments';
+import { useCategories } from './hooks/use-categories';
+import { useReserves } from './hooks/use-reserves';
+import { useReservationNavigation } from './hooks/use-reservation-navigation';
+import { useBulkReservation } from './hooks/use-bulk-reservation';
 
 const EquipmentList = () => {
-    const router = useRouter();
     const user = useCurrentUser();
-    const [ip, setIP] = useState<string | null>(null);
-    const [loading, startTransition] = useTransition();
-    const [loadingId, setLoadingId] = useState<number | null>(null);
-    const [equipments, setEquipments] = useState<Equipment[]>([]);
-    const [isBulkReservation, setIsBulkReservation] = useState(false); // まとめて予約モードの状態
-    const [selectedEquipments, setSelectedEquipments] = useState<Set<number>>(new Set()); // 選択された機材ID
-    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const { equipments, isLoading } = useEquipments();
+    const { categories, isLoading: categoriesLoading } = useCategories();
+    const { reserves, refetch: refetchReserves } = useReserves();
+    const { loadingId, isPending, navigateToReserve } = useReservationNavigation();
 
     // 選択されたカテゴリーを管理する状態
     const [selectedCategory, setSelectedCategory] = useState<string>('all');
 
-    // 取得したカテゴリーを保存する状態変数
-    const [categories, setCategories] = useState<{ id: string; name: string; color: string }[]>([]);
-    const [categoriesLoading, setCategoriesLoading] = useState<boolean>(true);
-
-    // 一括予約モーダル関連
-    const [showBulkModal, setShowBulkModal] = useState(false);
-    const [bulkReservation, setBulkReservation] = useState<BulkReservation>({ start: '', end: '' });
-    const [allReserves, setAllReserves] = useState<Reserve[]>([]);
-    const [isSubmitting, setIsSubmitting] = useState(false);
-
-    /* ユーザの情報をバックエンドに送る */
-    // const getIP = async () => {
-    //     try {
-    //         const res = await axios.get('https://api.ipify.org?format=json');
-    //         setIP(res.data.ip);
-    //     } catch (err) {
-    //         console.error("Error fetching IP:", err);
-    //     }
-    // };
-
-    // ユーザ情報をバックエンドに送信
-    // const pushUserData = async () => {
-    //     try {
-    //         const getUser = await axios.get(`https://logicode.fly.dev/users/${user?.id}`);
-    //         if (getUser.data) {
-    //             await axios.put(`https://logicode.fly.dev/users/${user?.id}`, {
-    //                 name: user?.name,
-    //                 ip: ip
-    //             });
-    //         } else {
-    //             await axios.post('https://logicode.fly.dev/users', {
-    //                 user_id: user?.id,
-    //                 name: user?.name,
-    //                 ip: ip
-    //             });
-    //         }
-    //     } catch (err) {
-    //         alert("ユーザー情報の処理中にエラーが発生しました。");
-    //     }
-    // }
-
-    // 各機材の予約ページに遷移
-    const handleReserveSubmit = (id: number) => {
-        setLoadingId(id);
-        startTransition(() => {
-            router.push('/ems/reserve/' + id);
-        });
-    };
-
-    // 機材データを取得する
-    const fetchEquipmentData = async () => {
-        const response = await fetch('/api/lists');
-        const data: Equipment[] = await response.json();
-
-        // 名前順（昇順）にソート
-        const sortedData = data.sort((a, b) => a.name.localeCompare(b.name));
-
-        setEquipments(sortedData);
-        setIsLoading(false);
-    };
-
-    // カテゴリデータを取得
-    const fetchCategories = async () => {
-        setCategoriesLoading(true);
-        try {
-            const response = await fetch("/api/tags");
-            const data = await response.json();
-            setCategories(data);
-        } catch (error) {
-            console.error("Error fetching categories: ", error);
-        } finally {
-            setCategoriesLoading(false);
-        }
-    }
+    const bulk = useBulkReservation({
+        userId: user?.id,
+        equipments,
+        reserves,
+        refetchReserves,
+    });
 
     // 選択されたカテゴリーに基づいて機材をフィルタリング
     const filteredEquipments = selectedCategory === 'all'
         ? equipments
         : equipments.filter(equipment => equipment.tag_id === selectedCategory);
-
-    // 全予約データを取得
-    const fetchAllReserves = async () => {
-        try {
-            const response = await fetch('/api/reserves');
-            const data: Reserve[] = await response.json();
-            setAllReserves(data);
-        } catch (error) {
-            console.error('Error fetching reserves:', error);
-        }
-    };
-
-    // 特定の機材の予約と新しい期間の重複をチェック
-    const isOverlapping = (listId: number, start: string, end: string): boolean => {
-        const newStart = new Date(start).getTime();
-        const newEnd = new Date(end).getTime();
-
-        const equipmentReserves = allReserves.filter(r => r.list_id === listId);
-
-        return equipmentReserves.some(reserve => {
-            const existingStart = new Date(reserve.start).getTime();
-            const existingEnd = new Date(reserve.end).getTime();
-
-            return (
-                (newStart >= existingStart && newStart <= existingEnd) ||
-                (newEnd >= existingStart && newEnd <= existingEnd) ||
-                (newStart <= existingStart && newEnd >= existingEnd)
-            );
-        });
-    };
-
-    // 全ての選択された機材について重複をチェック
-    const checkAllOverlaps = (start: string, end: string): { hasOverlap: boolean; conflictingEquipments: string[] } => {
-        const conflictingEquipments: string[] = [];
-
-        selectedEquipments.forEach(equipmentId => {
-            if (isOverlapping(equipmentId, start, end)) {
-                const equipment = equipments.find(e => e.id === equipmentId);
-                if (equipment) {
-                    conflictingEquipments.push(equipment.name);
-                }
-            }
-        });
-
-        return {
-            hasOverlap: conflictingEquipments.length > 0,
-            conflictingEquipments
-        };
-    };
-
-    const toggleBulkReservation = () => {
-        setIsBulkReservation(!isBulkReservation);
-        setSelectedEquipments(new Set()); // 初期化
-    };
-
-    const handleCheckboxChange = (equipmentId: number, checked: boolean) => {
-        setSelectedEquipments((prevSelected) => {
-            const newSelected = new Set(prevSelected);
-            if (checked) {
-                newSelected.add(equipmentId);
-            } else {
-                newSelected.delete(equipmentId);
-            }
-            return newSelected;
-        });
-    };
-
-    // まとめて予約モーダルを開く
-    const handleOpenBulkModal = async () => {
-        if (selectedEquipments.size === 0) {
-            alert("少なくとも1つの機材を選択してください。");
-            return;
-        }
-        // 最新の予約データを取得
-        await fetchAllReserves();
-        setShowBulkModal(true);
-    };
-
-    // 一括予約のサブミット処理
-    const handleBulkSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-
-        if (bulkReservation.start === '' || bulkReservation.end === '') {
-            alert('開始日と終了日を選択してください。');
-            return;
-        }
-
-        // 日付のバリデーション
-        const today = moment().tz('Asia/Tokyo').format('YYYY-MM-DD');
-        const start = moment(bulkReservation.start).tz('Asia/Tokyo').format('YYYY-MM-DD');
-        const end = moment(bulkReservation.end).tz('Asia/Tokyo').format('YYYY-MM-DD');
-
-        if (start < today || end < today || end < start) {
-            alert('無効な予約日です。開始日は今日以降、終了日は開始日以降を選択してください。');
-            return;
-        }
-
-        // 全ての機材について重複チェック
-        const { hasOverlap, conflictingEquipments } = checkAllOverlaps(bulkReservation.start, bulkReservation.end);
-
-        if (hasOverlap) {
-            alert(`以下の機材は選択した期間に既に予約が入っています：\n${conflictingEquipments.join('\n')}\n\n別の期間を選択してください。`);
-            return;
-        }
-
-        setIsSubmitting(true);
-
-        try {
-            // 選択された全ての機材に対して予約を作成
-            const selectedIds = Array.from(selectedEquipments);
-
-            // 日付文字列（'YYYY-MM-DD'形式）をそのままAPIに送信
-            // APIで日本時間の日付として正しく処理される
-            const promises = selectedIds.map(listId =>
-                axios.post('/api/reserves', {
-                    user_id: user?.id,
-                    start: bulkReservation.start,
-                    end: bulkReservation.end,
-                    list_id: listId
-                })
-            );
-
-            await Promise.all(promises);
-
-            alert(`${selectedIds.length}件の予約が正常に完了しました。`);
-
-            // 状態をリセット
-            setShowBulkModal(false);
-            setBulkReservation({ start: '', end: '' });
-            setSelectedEquipments(new Set());
-            setIsBulkReservation(false);
-        } catch (error) {
-            console.error('Error creating bulk reservations:', error);
-            alert('予約の作成中にエラーが発生しました。');
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
-    // モーダルを閉じる
-    const handleCloseBulkModal = () => {
-        setShowBulkModal(false);
-        setBulkReservation({ start: '', end: '' });
-    };
-
-    useEffect(() => {
-        fetchEquipmentData();
-        fetchCategories();
-        fetchAllReserves();
-    }, []);
 
     return (
         <div className='bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))]
@@ -269,29 +43,29 @@ const EquipmentList = () => {
                 <div className='flex justify-between items-center flex-wrap gap-2'>
                     <p className='text-xl ml-1'>予約</p>
                     <div className='flex items-center gap-2 ml-auto'>
-                        {isBulkReservation ? (
+                        {bulk.isBulkMode ? (
                             <div className='flex gap-2'>
                                 <Button
                                     colorScheme='gray'
                                     size='sm'
-                                    onClick={toggleBulkReservation}
+                                    onClick={bulk.toggleBulkMode}
                                 >
                                     キャンセル
                                 </Button>
                                 <Button
                                     colorScheme='orange'
                                     size='sm'
-                                    onClick={handleOpenBulkModal}
-                                    isDisabled={selectedEquipments.size === 0}
+                                    onClick={bulk.openModal}
+                                    isDisabled={bulk.selectedIds.size === 0}
                                 >
-                                    予約する ({selectedEquipments.size}件)
+                                    予約する ({bulk.selectedIds.size}件)
                                 </Button>
                             </div>
                         ) : (
                             <Button
                                 colorScheme='orange'
                                 size='sm'
-                                onClick={toggleBulkReservation}
+                                onClick={bulk.toggleBulkMode}
                             >
                                 まとめて予約
                             </Button>
@@ -326,29 +100,29 @@ const EquipmentList = () => {
                                         </div>
 
                                         <div className="flex items-center ml-auto">
-                                            {loading && loadingId === equipment.id ? (
+                                            {isPending && loadingId === equipment.id ? (
                                                 <Button
                                                     isLoading
-                                                    disabled={loading && loadingId === equipment.id}
-                                                    onClick={() => handleReserveSubmit(equipment.id)}
+                                                    disabled={isPending && loadingId === equipment.id}
+                                                    onClick={() => navigateToReserve(equipment.id)}
                                                     colorScheme='blue'
                                                 >
                                                     選択
                                                 </Button>
                                             ) : (
                                                 <>
-                                                    {isBulkReservation ? (
+                                                    {bulk.isBulkMode ? (
                                                         <Button
                                                             size='sm'
-                                                            colorScheme={selectedEquipments.has(equipment.id) ? 'green' : 'gray'}
-                                                            onClick={() => handleCheckboxChange(equipment.id, !selectedEquipments.has(equipment.id))}
+                                                            colorScheme={bulk.selectedIds.has(equipment.id) ? 'green' : 'gray'}
+                                                            onClick={() => bulk.toggleEquipment(equipment.id, !bulk.selectedIds.has(equipment.id))}
                                                         >
-                                                            {selectedEquipments.has(equipment.id) ? '選択中' : '選択'}
+                                                            {bulk.selectedIds.has(equipment.id) ? '選択中' : '選択'}
                                                         </Button>
                                                     ) : (
                                                         <Button
-                                                            disabled={loading && loadingId === equipment.id}
-                                                            onClick={() => handleReserveSubmit(equipment.id)}
+                                                            disabled={isPending && loadingId === equipment.id}
+                                                            onClick={() => navigateToReserve(equipment.id)}
                                                             colorScheme='blue'
                                                         >
                                                             選択
@@ -374,8 +148,8 @@ const EquipmentList = () => {
             </div >
 
             {/* 一括予約モーダル */}
-            <Transition.Root show={showBulkModal} as={Fragment}>
-                <Dialog as="div" className="relative z-10" onClose={handleCloseBulkModal}>
+            <Transition.Root show={bulk.showModal} as={Fragment}>
+                <Dialog as="div" className="relative z-10" onClose={bulk.closeModal}>
                     <Transition.Child
                         as={Fragment}
                         enter="ease-out duration-300"
@@ -409,12 +183,12 @@ const EquipmentList = () => {
                                                 まとめて予約
                                             </Dialog.Title>
                                             <p className="mt-2 text-sm text-gray-500">
-                                                選択した{selectedEquipments.size}件の機材を借りる期間を選択してください
+                                                選択した{bulk.selectedIds.size}件の機材を借りる期間を選択してください
                                             </p>
                                             <div className="mt-2 text-left">
                                                 <p className="text-xs text-gray-400 mb-2">選択中の機材:</p>
                                                 <div className="max-h-24 overflow-y-auto bg-gray-50 rounded p-2">
-                                                    {Array.from(selectedEquipments).map(id => {
+                                                    {Array.from(bulk.selectedIds).map(id => {
                                                         const equipment = equipments.find(e => e.id === id);
                                                         return equipment ? (
                                                             <span key={id} className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded mr-1 mb-1">
@@ -424,14 +198,14 @@ const EquipmentList = () => {
                                                     })}
                                                 </div>
                                             </div>
-                                            <form onSubmit={handleBulkSubmit}>
+                                            <form onSubmit={bulk.submit}>
                                                 <div className="mt-4">
                                                     <label className="block text-sm font-medium text-gray-700 text-left">開始日</label>
                                                     <input
                                                         type="date"
                                                         name="start"
-                                                        value={bulkReservation.start}
-                                                        onChange={(e) => setBulkReservation({ ...bulkReservation, start: e.target.value })}
+                                                        value={bulk.bulkForm.start}
+                                                        onChange={(e) => bulk.updateForm({ start: e.target.value })}
                                                         className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-violet-600"
                                                     />
                                                 </div>
@@ -440,23 +214,23 @@ const EquipmentList = () => {
                                                     <input
                                                         type="date"
                                                         name="end"
-                                                        value={bulkReservation.end}
-                                                        onChange={(e) => setBulkReservation({ ...bulkReservation, end: e.target.value })}
+                                                        value={bulk.bulkForm.end}
+                                                        onChange={(e) => bulk.updateForm({ end: e.target.value })}
                                                         className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-violet-600"
                                                     />
                                                 </div>
                                                 <div className="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
                                                     <button
                                                         type="submit"
-                                                        disabled={isSubmitting || bulkReservation.start === '' || bulkReservation.end === ''}
+                                                        disabled={bulk.isSubmitting || bulk.bulkForm.start === '' || bulk.bulkForm.end === ''}
                                                         className="inline-flex w-full justify-center rounded-md bg-violet-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-violet-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-600 sm:col-start-2 disabled:opacity-25"
                                                     >
-                                                        {isSubmitting ? '予約中...' : '予約確定'}
+                                                        {bulk.isSubmitting ? '予約中...' : '予約確定'}
                                                     </button>
                                                     <button
                                                         type="button"
                                                         className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
-                                                        onClick={handleCloseBulkModal}
+                                                        onClick={bulk.closeModal}
                                                     >
                                                         戻る
                                                     </button>

--- a/lib/reservation-overlap.test.ts
+++ b/lib/reservation-overlap.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { Equipment, Reserve } from "@/types/domain";
+import { checkAllOverlaps, isOverlapping } from "./reservation-overlap";
+
+const makeReserve = (partial: Partial<Reserve>): Reserve => ({
+  id: 1,
+  user_id: "u1",
+  start: "2026-01-01",
+  end: "2026-01-02",
+  list_id: 1,
+  ...partial,
+});
+
+const makeEquipment = (partial: Partial<Equipment>): Equipment => ({
+  id: 1,
+  name: "Camera",
+  detail: "",
+  image: "",
+  tag_id: "1",
+  ...partial,
+});
+
+describe("isOverlapping", () => {
+  it("returns false when there are no reserves for the list", () => {
+    expect(isOverlapping([], 1, "2026-01-10", "2026-01-12")).toBe(false);
+  });
+
+  it("returns false when reserves exist only for other list_ids", () => {
+    const reserves = [makeReserve({ list_id: 2, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-10", "2026-01-12")).toBe(false);
+  });
+
+  it("returns false when ranges do not overlap (new is before existing)", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-01", "2026-01-05")).toBe(false);
+  });
+
+  it("returns false when ranges do not overlap (new is after existing)", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-20", "2026-01-25")).toBe(false);
+  });
+
+  it("returns true when newStart falls inside an existing range", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-12", "2026-01-20")).toBe(true);
+  });
+
+  it("returns true when newEnd falls inside an existing range", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-05", "2026-01-12")).toBe(true);
+  });
+
+  it("returns true when new range completely contains an existing one", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-05", "2026-01-20")).toBe(true);
+  });
+
+  it("returns true when new range is contained within existing", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-20" })];
+    expect(isOverlapping(reserves, 1, "2026-01-12", "2026-01-15")).toBe(true);
+  });
+
+  it("returns true on exact boundary touch (start == end)", () => {
+    const reserves = [makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" })];
+    expect(isOverlapping(reserves, 1, "2026-01-15", "2026-01-20")).toBe(true);
+  });
+});
+
+describe("checkAllOverlaps", () => {
+  const equipments = [
+    makeEquipment({ id: 1, name: "Camera" }),
+    makeEquipment({ id: 2, name: "Tripod" }),
+    makeEquipment({ id: 3, name: "Microphone" }),
+  ];
+
+  it("returns hasOverlap=false when nothing conflicts", () => {
+    const result = checkAllOverlaps([], equipments, [1, 2], "2026-01-10", "2026-01-12");
+    expect(result).toEqual({ hasOverlap: false, conflictingEquipments: [] });
+  });
+
+  it("returns the name of the single conflicting equipment", () => {
+    const reserves = [makeReserve({ list_id: 2, start: "2026-01-10", end: "2026-01-15" })];
+    const result = checkAllOverlaps(reserves, equipments, [1, 2], "2026-01-12", "2026-01-20");
+    expect(result).toEqual({ hasOverlap: true, conflictingEquipments: ["Tripod"] });
+  });
+
+  it("returns multiple conflicting names when several overlap", () => {
+    const reserves = [
+      makeReserve({ list_id: 1, start: "2026-01-10", end: "2026-01-15" }),
+      makeReserve({ list_id: 3, start: "2026-01-10", end: "2026-01-15" }),
+    ];
+    const result = checkAllOverlaps(reserves, equipments, [1, 2, 3], "2026-01-12", "2026-01-13");
+    expect(result.hasOverlap).toBe(true);
+    expect(result.conflictingEquipments.sort()).toEqual(["Camera", "Microphone"]);
+  });
+
+  it("dedupes names when the same equipment has multiple overlapping reserves", () => {
+    const reserves = [
+      makeReserve({ id: 10, list_id: 1, start: "2026-01-10", end: "2026-01-12" }),
+      makeReserve({ id: 11, list_id: 1, start: "2026-01-14", end: "2026-01-16" }),
+    ];
+    const result = checkAllOverlaps(reserves, equipments, [1], "2026-01-11", "2026-01-15");
+    expect(result.conflictingEquipments).toEqual(["Camera"]);
+  });
+
+  it("ignores selected ids that are not in the equipments array", () => {
+    const reserves = [makeReserve({ list_id: 999, start: "2026-01-10", end: "2026-01-15" })];
+    const result = checkAllOverlaps(reserves, equipments, [999], "2026-01-12", "2026-01-13");
+    expect(result).toEqual({ hasOverlap: false, conflictingEquipments: [] });
+  });
+
+  it("accepts Set<number> as selectedIds", () => {
+    const reserves = [makeReserve({ list_id: 2, start: "2026-01-10", end: "2026-01-15" })];
+    const result = checkAllOverlaps(reserves, equipments, new Set([1, 2]), "2026-01-12", "2026-01-13");
+    expect(result.conflictingEquipments).toEqual(["Tripod"]);
+  });
+});

--- a/lib/reservation-overlap.ts
+++ b/lib/reservation-overlap.ts
@@ -1,0 +1,57 @@
+import type { Equipment, Reserve } from "@/types/domain";
+
+/**
+ * 特定の機材について、既存予約と新しい予約期間が重なるか判定する。
+ * 「重なる」: 新規開始が既存範囲内 or 新規終了が既存範囲内 or 既存全体を新規が包含。
+ */
+export const isOverlapping = (
+  reserves: Reserve[],
+  listId: number,
+  start: string,
+  end: string,
+): boolean => {
+  const newStart = new Date(start).getTime();
+  const newEnd = new Date(end).getTime();
+
+  const equipmentReserves = reserves.filter((r) => r.list_id === listId);
+
+  return equipmentReserves.some((reserve) => {
+    const existingStart = new Date(reserve.start).getTime();
+    const existingEnd = new Date(reserve.end).getTime();
+
+    return (
+      (newStart >= existingStart && newStart <= existingEnd) ||
+      (newEnd >= existingStart && newEnd <= existingEnd) ||
+      (newStart <= existingStart && newEnd >= existingEnd)
+    );
+  });
+};
+
+/**
+ * 選択された機材すべてについて期間重複をチェックし、衝突した機材の名前リストを返す。
+ * 重複名は 1 つに束ねる。equipments に存在しない id は無視。
+ */
+export const checkAllOverlaps = (
+  reserves: Reserve[],
+  equipments: Equipment[],
+  selectedIds: ReadonlySet<number> | readonly number[],
+  start: string,
+  end: string,
+): { hasOverlap: boolean; conflictingEquipments: string[] } => {
+  const conflictingNames = new Set<string>();
+
+  const ids = Array.isArray(selectedIds) ? selectedIds : Array.from(selectedIds);
+  for (const equipmentId of ids) {
+    if (isOverlapping(reserves, equipmentId, start, end)) {
+      const equipment = equipments.find((e) => e.id === equipmentId);
+      if (equipment) {
+        conflictingNames.add(equipment.name);
+      }
+    }
+  }
+
+  return {
+    hasOverlap: conflictingNames.size > 0,
+    conflictingEquipments: Array.from(conflictingNames),
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/uuid": "^9.0.8",
+        "@vitejs/plugin-react": "^6.0.2",
         "@vitest/ui": "^4.1.6",
         "eslint": "^8",
         "eslint-config-next": "14.2.2",
@@ -4300,6 +4301,32 @@
           "optional": true
         },
         "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/uuid": "^9.0.8",
+    "@vitejs/plugin-react": "^6.0.2",
     "@vitest/ui": "^4.1.6",
     "eslint": "^8",
     "eslint-config-next": "14.2.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     environment: "happy-dom",
     globals: true,


### PR DESCRIPTION
## Summary
Phase 2a-1: equipment-list/page.tsx (478 行) のメガコンポーネント分解。**動作変更ゼロ**。

## 抽出した hooks / helper

| ファイル | 責務 |
|---|---|
| `lib/reservation-overlap.ts` | 純粋関数: \`isOverlapping\`, \`checkAllOverlaps\` |
| `hooks/use-equipments.ts` | \`/api/lists\` fetch + name 順ソート |
| `hooks/use-categories.ts` | \`/api/tags\` fetch |
| `hooks/use-reserves.ts` | \`/api/reserves\` fetch + refetch |
| `hooks/use-reservation-navigation.ts` | \`useRouter\`/\`useTransition\` で予約ページ遷移 |
| `hooks/use-bulk-reservation.ts` | bulk 予約全フロー (toggle, modal, validation, overlap, POST, reset) |

## テスト
+42 件 / 累計 132 件、全 pass。
- 純粋関数: 15 件（前後重なり・完全包含・隣接・dedupe・null id 等の境界ケース）
- データ取得 hooks: 10 件（mount fetch / refetch / error path）
- ロジック hooks: 14 件（全 alert 分岐 + 成功時の状態リセット + POST 失敗時の isSubmitting 復帰）
- page.test.tsx: 3 件（軽量統合テスト: ローディング / 一覧表示 / 空状態）

## ビルド基盤の追加
\`@vitejs/plugin-react\` を devDep に追加（\`.test.tsx\` の JSX を扱うため）。

## 動作変更ゼロの担保
- JSX の DOM 構造 / className / props 値は完全維持（state を hook 経由に置換のみ）
- useEffect の依存配列・タイミング不変（hook 内も初回マウント 1 回のみ fetch）
- ロジック本体は丸ごとコピー、引数化したのは純粋関数のみ
- \`npm test\` 132/132 / \`npm run lint\` 既存警告のみ / \`npm run build\` 成功

## Test plan
- [ ] Vercel Preview デプロイで実機確認
- [ ] **機材一覧**: カテゴリ All → 名前順表示
- [ ] **カテゴリ絞り込み**: Select → フィルタリング
- [ ] **「選択」ボタン**: \`/ems/reserve/<id>\` 遷移 + ローディング表示
- [ ] **まとめて予約 ON/OFF**: ボタン色変化、選択リセット
- [ ] **複数機材選択 → モーダル**: 日付バリデーション（空・過去・end<start・重複機材）
- [ ] **全件 OK で予約完了**: POST 並列、alert、状態リセット
- [ ] DevTools Network で \`/api/lists\`/\`/api/tags\`/\`/api/reserves\` が初回各 1 回呼ばれる

## 次フェーズへの含み
同パターンで manager (426 行) / 3 つの calendar (400+ 行) / mypage / reserve も分解可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)