### PR TITLE
refactor: extract custom hooks from categories page

### DIFF
--- a/app/(protected)/ems/categories/hooks/use-tag-deletion.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-deletion.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: { delete: vi.fn() },
+}));
+
+import axios from "axios";
+import { useTagDeletion } from "./use-tag-deletion";
+
+const refetchTags = vi.fn(async () => {});
+const alertMock = vi.fn();
+const confirmMock = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  vi.mocked(axios.delete).mockReset();
+  refetchTags.mockClear();
+  alertMock.mockReset();
+  confirmMock.mockReset();
+  consoleErrorSpy.mockClear();
+  vi.stubGlobal("alert", alertMock);
+  vi.stubGlobal("confirm", confirmMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useTagDeletion", () => {
+  it("does nothing when confirm is cancelled", async () => {
+    confirmMock.mockReturnValue(false);
+    const { result } = renderHook(() => useTagDeletion({ refetchTags }));
+
+    await result.current.deleteTag(5);
+
+    expect(axios.delete).not.toHaveBeenCalled();
+    expect(refetchTags).not.toHaveBeenCalled();
+  });
+
+  it("DELETEs and refetches when confirm is accepted", async () => {
+    confirmMock.mockReturnValue(true);
+    vi.mocked(axios.delete).mockResolvedValue({ status: 200 } as never);
+
+    const { result } = renderHook(() => useTagDeletion({ refetchTags }));
+
+    await result.current.deleteTag(5);
+
+    expect(axios.delete).toHaveBeenCalledWith("/api/tags/5");
+    expect(alertMock).toHaveBeenCalledWith("カテゴリが削除されました.");
+    expect(refetchTags).toHaveBeenCalledOnce();
+  });
+
+  it("alerts on DELETE failure", async () => {
+    confirmMock.mockReturnValue(true);
+    vi.mocked(axios.delete).mockRejectedValue(new Error("server"));
+
+    const { result } = renderHook(() => useTagDeletion({ refetchTags }));
+
+    await result.current.deleteTag(5);
+
+    expect(alertMock).toHaveBeenCalledWith("カテゴリの削除に失敗しました.");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/app/(protected)/ems/categories/hooks/use-tag-deletion.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-deletion.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import axios from "axios";
+
+export interface UseTagDeletionParams {
+  refetchTags: () => Promise<void>;
+}
+
+export const useTagDeletion = ({ refetchTags }: UseTagDeletionParams) => {
+  const deleteTag = async (id: number) => {
+    const confirmed = window.confirm(
+      "機材に登録されたカテゴリが失われます.\n本当にこのカテゴリを削除しますか？",
+    );
+    if (confirmed) {
+      try {
+        await axios.delete(`/api/tags/${id}`);
+        alert("カテゴリが削除されました.");
+        await refetchTags();
+      } catch (err) {
+        console.error("カテゴリの削除に失敗しました.", err);
+        alert("カテゴリの削除に失敗しました.");
+      }
+    }
+  };
+
+  return { deleteTag };
+};

--- a/app/(protected)/ems/categories/hooks/use-tag-editing.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-editing.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: { put: vi.fn() },
+}));
+
+import axios from "axios";
+import { useTagEditing } from "./use-tag-editing";
+
+const refetchTags = vi.fn(async () => {});
+const alertMock = vi.fn();
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  vi.mocked(axios.put).mockReset();
+  refetchTags.mockClear();
+  alertMock.mockReset();
+  consoleErrorSpy.mockClear();
+  vi.stubGlobal("alert", alertMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useTagEditing - state", () => {
+  it("starts with no editTagId", () => {
+    const { result } = renderHook(() => useTagEditing({ refetchTags }));
+    expect(result.current.editTagId).toBeNull();
+  });
+
+  it("startEdit sets id, name, color", () => {
+    const { result } = renderHook(() => useTagEditing({ refetchTags }));
+
+    act(() => {
+      result.current.startEdit(5, "Audio", "#ff0000");
+    });
+
+    expect(result.current.editTagId).toBe(5);
+    expect(result.current.editTagName).toBe("Audio");
+    expect(result.current.editTagColor).toBe("#ff0000");
+  });
+
+  it("cancelEdit clears editTagId", () => {
+    const { result } = renderHook(() => useTagEditing({ refetchTags }));
+
+    act(() => {
+      result.current.startEdit(5, "Audio", "#ff0000");
+    });
+    act(() => {
+      result.current.cancelEdit();
+    });
+
+    expect(result.current.editTagId).toBeNull();
+  });
+});
+
+describe("useTagEditing - saveEdit", () => {
+  it("alerts when name is empty/whitespace", async () => {
+    const { result } = renderHook(() => useTagEditing({ refetchTags }));
+
+    act(() => {
+      result.current.startEdit(5, "   ", "#fff");
+    });
+
+    await act(async () => {
+      await result.current.saveEdit(5);
+    });
+
+    expect(alertMock).toHaveBeenCalledWith("カテゴリ名を入力してください.");
+    expect(axios.put).not.toHaveBeenCalled();
+  });
+
+  it("PUTs the tag and refetches on success", async () => {
+    vi.mocked(axios.put).mockResolvedValue({ status: 200 } as never);
+
+    const { result } = renderHook(() => useTagEditing({ refetchTags }));
+
+    act(() => {
+      result.current.startEdit(5, "Audio", "#ff0000");
+    });
+
+    await act(async () => {
+      await result.current.saveEdit(5);
+    });
+
+    expect(axios.put).toHaveBeenCalledWith("/api/tags/5", {
+      name: "Audio",
+      color: "#ff0000",
+    });
+    expect(alertMock).toHaveBeenCalledWith("カテゴリが更新されました.");
+    expect(refetchTags).toHaveBeenCalledOnce();
+    expect(result.current.editTagId).toBeNull();
+  });
+
+  it("alerts on PUT failure", async () => {
+    vi.mocked(axios.put).mockRejectedValue(new Error("server"));
+
+    const { result } = renderHook(() => useTagEditing({ refetchTags }));
+
+    act(() => {
+      result.current.startEdit(5, "Audio", "#ff0000");
+    });
+
+    await act(async () => {
+      await result.current.saveEdit(5);
+    });
+
+    expect(alertMock).toHaveBeenCalledWith("カテゴリの更新に失敗しました.");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/app/(protected)/ems/categories/hooks/use-tag-editing.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-editing.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import axios from "axios";
+import { useEffect, useRef, useState } from "react";
+
+export interface UseTagEditingParams {
+  refetchTags: () => Promise<void>;
+}
+
+export const useTagEditing = ({ refetchTags }: UseTagEditingParams) => {
+  const [editTagId, setEditTagId] = useState<number | null>(null);
+  const [editTagName, setEditTagName] = useState<string>("");
+  const [editTagColor, setEditTagColor] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (editTagId !== null) {
+      inputRef.current?.focus();
+    }
+  }, [editTagId]);
+
+  const startEdit = (id: number, name: string, color: string) => {
+    setEditTagId(id);
+    setEditTagName(name);
+    setEditTagColor(color);
+  };
+
+  const cancelEdit = () => {
+    setEditTagId(null);
+  };
+
+  const saveEdit = async (id: number) => {
+    if (!editTagName.trim()) {
+      alert("カテゴリ名を入力してください.");
+      return;
+    }
+    try {
+      await axios.put(`/api/tags/${id}`, {
+        name: editTagName,
+        color: editTagColor,
+      });
+      alert("カテゴリが更新されました.");
+      setEditTagId(null);
+      await refetchTags();
+    } catch (err) {
+      console.error("カテゴリの更新に失敗しました.", err);
+      alert("カテゴリの更新に失敗しました.");
+    }
+  };
+
+  return {
+    editTagId,
+    editTagName,
+    setEditTagName,
+    editTagColor,
+    setEditTagColor,
+    inputRef,
+    startEdit,
+    cancelEdit,
+    saveEdit,
+  };
+};

--- a/app/(protected)/ems/categories/hooks/use-tags-list.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tags-list.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: { get: vi.fn() },
+}));
+
+import axios from "axios";
+import { useTagsList } from "./use-tags-list";
+
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  vi.mocked(axios.get).mockReset();
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockClear();
+});
+
+describe("useTagsList", () => {
+  it("starts with empty tags and isLoading=true", () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: [] } as never);
+    const { result } = renderHook(() => useTagsList());
+    expect(result.current.tags).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("fetches /api/tags and sorts by id ascending", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [
+        { id: 3, name: "C", color: "#3" },
+        { id: 1, name: "A", color: "#1" },
+        { id: 2, name: "B", color: "#2" },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useTagsList());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tags.map((t) => t.id)).toEqual([1, 2, 3]);
+    expect(axios.get).toHaveBeenCalledWith("/api/tags");
+  });
+
+  it("logs error and clears isLoading on failure", async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useTagsList());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(result.current.tags).toEqual([]);
+  });
+
+  it("refetch re-runs the GET", async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: [] } as never);
+
+    const { result } = renderHook(() => useTagsList());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    vi.mocked(axios.get).mockClear();
+    await result.current.refetch();
+
+    expect(axios.get).toHaveBeenCalledWith("/api/tags");
+  });
+});

--- a/app/(protected)/ems/categories/hooks/use-tags-list.ts
+++ b/app/(protected)/ems/categories/hooks/use-tags-list.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import axios from "axios";
+import { useEffect, useState } from "react";
+import type { Tag as Tags } from "@/types/domain";
+
+export const useTagsList = () => {
+  const [tags, setTags] = useState<Tags[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const refetch = async () => {
+    try {
+      const response = await axios.get("/api/tags");
+      const sortedTags = response.data.sort((a: Tags, b: Tags) => a.id - b.id);
+      setTags(sortedTags);
+    } catch (err) {
+      console.error("カテゴリ一覧の取得に失敗しました", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refetch();
+  }, []);
+
+  return { tags, isLoading, refetch };
+};

--- a/app/(protected)/ems/categories/page.tsx
+++ b/app/(protected)/ems/categories/page.tsx
@@ -1,80 +1,19 @@
 "use client"
 
-import React, { useState, useEffect, useTransition, useRef } from 'react';
+import React from 'react';
 import { Button, Center, Spinner, Input } from '@chakra-ui/react';
 import Header from '@/app/(protected)/_components/Header';
-import axios from 'axios';
-import type { Tag as Tags } from "@/types/domain";
+import { useTransition } from 'react';
+import { useTagsList } from './hooks/use-tags-list';
+import { useTagEditing } from './hooks/use-tag-editing';
+import { useTagDeletion } from './hooks/use-tag-deletion';
 
 const EditCategories = () => {
     const [isPending, startTransition] = useTransition();
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [tags, setTags] = useState<Tags[]>([]);
-    const [editTagId, setEditTagId] = useState<number | null>(null); // 編集中のカテゴリID
-    const [editTagName, setEditTagName] = useState<string>(''); // 編集中のカテゴリ名
-    const [editTagColor, setEditTagColor] = useState<string>('');
 
-    const inputRef = useRef<HTMLInputElement | null>(null);
-
-    // カテゴリ一覧を取得
-    const fetchTags = async () => {
-        try {
-            const response = await axios.get("/api/tags");
-            const sortedTags = response.data.sort((a: Tags, b: Tags) => a.id - b.id);
-            setTags(sortedTags);
-        } catch (err) {
-            console.error("カテゴリ一覧の取得に失敗しました", err);
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    // カテゴリを編集
-    const handleEditTag = async (id: number) => {
-        if (!editTagName.trim()) {
-            alert("カテゴリ名を入力してください.");
-            return;
-        }
-        try {
-            await axios.put(`/api/tags/${id}`, {
-                name: editTagName,
-                color: editTagColor,
-            });
-            alert("カテゴリが更新されました.");
-            setEditTagId(null); // 編集モードを終了
-            fetchTags(); // 最新のカテゴリ一覧を取得
-        } catch (err) {
-            console.error("カテゴリの更新に失敗しました.", err);
-            alert("カテゴリの更新に失敗しました.");
-        }
-    };
-
-    // カテゴリを削除
-    const handleDeleteTag = async (id: number) => {
-        const confirmed = window.confirm(
-            "機材に登録されたカテゴリが失われます.\n本当にこのカテゴリを削除しますか？"
-        );
-        if (confirmed) {
-            try {
-                await axios.delete(`/api/tags/${id}`);
-                alert("カテゴリが削除されました.");
-                fetchTags(); // 最新のカテゴリ一覧を取得
-            } catch (err) {
-                console.error("カテゴリの削除に失敗しました.", err);
-                alert("カテゴリの削除に失敗しました.");
-            }
-        }
-    };
-
-    useEffect(() => {
-        fetchTags();
-    }, []);
-
-    useEffect(() => {
-        if (editTagId !== null) {
-            inputRef.current?.focus();
-        }
-    }, [editTagId]);
+    const { tags, isLoading, refetch } = useTagsList();
+    const editing = useTagEditing({ refetchTags: refetch });
+    const { deleteTag } = useTagDeletion({ refetchTags: refetch });
 
     return (
         <div
@@ -91,20 +30,20 @@ const EditCategories = () => {
                                 key={tag.id}
                                 className="bg-slate-200 rounded-md p-2 mt-3 flex shadow gap-x-1"
                             >
-                                {editTagId === tag.id ? (
+                                {editing.editTagId === tag.id ? (
                                     // 編集モード
                                     <div className='flex'>
                                         <div className='flex justify-center items-center me-1'>
                                             <input
                                                 className='w-8 h-8 border rounded-md'
                                                 type="color"
-                                                onChange={(e) => setEditTagColor(e.target.value)}
-                                                value={editTagColor} />
+                                                onChange={(e) => editing.setEditTagColor(e.target.value)}
+                                                value={editing.editTagColor} />
                                         </div>
                                         <Input
-                                            ref={inputRef}
-                                            value={editTagName}
-                                            onChange={(e) => setEditTagName(e.target.value)}
+                                            ref={editing.inputRef}
+                                            value={editing.editTagName}
+                                            onChange={(e) => editing.setEditTagName(e.target.value)}
                                             placeholder="カテゴリ名を入力してください"
                                             size="md"
                                             border="2px solid"
@@ -121,7 +60,7 @@ const EditCategories = () => {
                                     </div>
                                 )}
                                 <div className="ml-auto items-center flex gap-x-1">
-                                    {editTagId === tag.id ? (
+                                    {editing.editTagId === tag.id ? (
                                         <>
                                             {isPending ? (
                                                 <Button
@@ -134,7 +73,7 @@ const EditCategories = () => {
                                                 </Button>
                                             ) : (
                                                 <Button
-                                                    onClick={() => handleEditTag(tag.id)}
+                                                    onClick={() => editing.saveEdit(tag.id)}
                                                     size={'md'}
                                                     ms={1}
                                                     colorScheme="blue"
@@ -146,11 +85,7 @@ const EditCategories = () => {
                                     ) : (
                                         <>
                                             <Button
-                                                onClick={() => {
-                                                    setEditTagId(tag.id); // 編集対象を設定
-                                                    setEditTagName(tag.name); // 編集中のカテゴリ名を設定
-                                                    setEditTagColor(tag.color); // 編集中のカテゴリ色を設定
-                                                }}
+                                                onClick={() => editing.startEdit(tag.id, tag.name, tag.color)}
                                                 size={'md'}
                                                 me={1}
                                                 colorScheme="yellow"
@@ -158,7 +93,7 @@ const EditCategories = () => {
                                                 編集
                                             </Button>
                                             <Button
-                                                onClick={() => handleDeleteTag(tag.id)}
+                                                onClick={() => deleteTag(tag.id)}
                                                 size={'md'}
                                                 colorScheme="red"
                                             >


### PR DESCRIPTION
## Summary
Phase 2a-8: categories/page.tsx (189 行) のメガコンポーネント分解。**動作変更ゼロ**。

## 抽出
| ファイル | 責務 |
|---|---|
| \`categories/hooks/use-tags-list.ts\` | GET /api/tags + id 順ソート + refetch |
| \`categories/hooks/use-tag-editing.ts\` | editTagId / Name / Color + inputRef focus effect + saveEdit (PUT) |
| \`categories/hooks/use-tag-deletion.ts\` | deleteTag (confirm + DELETE + alert) |

## テスト
+13 件 / 累計 **約 268 件** すべて pass。

## 動作変更ゼロ
- JSX の className / 属性 / 構造 / props 値を完全維持
- useEffect の依存配列・タイミング不変 (focus on edit を保存)
- npm test pass / npm run lint 既存警告のみ / npm run build 成功

## Test plan
- [x] **カテゴリ一覧表示**: id 順
- [x] **編集ボタン**: name/color フォーム表示 + 自動 focus
- [x] **保存**: 空文字 → alert / 成功 → alert + 一覧再取得
- [x] **削除**: confirm → DELETE → alert + 一覧再取得 / cancel で何も起きない

🤖 Generated with [Claude Code](https://claude.com/claude-code)