### PR TITLE
旧サイト(Vercel)→abs-ems.forgeonics.com へ307リダイレクト

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "destination": "https://abs-ems.forgeonics.com/:path*",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
## 目的
Cloudflare Workers への本番移行（カットオーバー）に伴い、部員が利用中の **abs-ems.vercel.app** から新本番 **https://abs-ems.forgeonics.com** へ全パスを 307 リダイレクトする。

## 内容
- `vercel.json` 新規追加（redirects のみ）
- `permanent: false`（307）で開始 → 安定稼働後に 308 へ変更予定
- Workers 側は `vercel.json` を読まないため新環境には無影響

## ⚠️ マージのタイミング
**新ドメインでの実アカウントログイン確認（スモークテスト）合格後にマージしてください。** マージ→Vercel 自動デプロイの瞬間から部員は新ドメインへ転送されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqUJzxQBp26xzmFh3hZMB8