### PR TITLE
fix: ルート(/)のリダイレクト漏れを修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
   "redirects": [
     {
+      "source": "/",
+      "destination": "https://abs-ems.forgeonics.com/",
+      "permanent": false
+    },
+    {
       "source": "/:path*",
       "destination": "https://abs-ems.forgeonics.com/:path*",
       "permanent": false


### PR DESCRIPTION
## 問題
PR #49 の `/:path*` パターンは **ルート `/` そのものにマッチしない**（Vercel の実挙動）。
実測: `/ems/mypage`・`/auth/login` → 307 ✅、`/` → 200（未転送）❌

## 修正
明示の `"/"` ルールを追加。部員のブックマークは大半がルートのはずなので必須。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqUJzxQBp26xzmFh3hZMB8