### PR TITLE
fix: 本番データ規模のカレンダー巨大化を修正 + マイ予約の一括操作

### DIFF
--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -77,8 +77,8 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         barEvents,
         matrix,
         isDesktop
-          ? { headH: 26, laneH: 26, minH: 104 }
-          : { headH: 20, laneH: 20, minH: 62 }
+          ? { headH: 26, laneH: 26, minH: 104, maxLanes: 6 }
+          : { headH: 20, laneH: 20, minH: 62, maxLanes: 4 }
       ),
     [barEvents, matrix, isDesktop]
   );
@@ -193,7 +193,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
       {view === "month" ? (
         // grid-cols-1（minmax(0,1fr)）を明示しないと、モバイルでトラックが
         // コンテンツ幅に広がり画面からはみ出す
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_320px]">
           <div className="rounded-2xl bg-white p-4 shadow-sm">
             <MemberChips
               members={members}

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -209,7 +209,7 @@ export function BookingWizard() {
   return (
     <>
       {/* デスクトップ: 3カラム同時表示 */}
-      <div className="hidden md:grid md:grid-cols-[340px_1fr_320px] md:items-start md:gap-4">
+      <div className="hidden md:grid md:grid-cols-[340px_minmax(0,1fr)_320px] md:items-start md:gap-4">
         {periodPanel}
         <div>
           <div className="mb-3 flex items-center gap-2 px-1">

--- a/app/(protected)/ems/manager/page.tsx
+++ b/app/(protected)/ems/manager/page.tsx
@@ -107,7 +107,7 @@ export default function ManagerPage() {
       </div>
 
       {/* PC: 2ペイン */}
-      <div className="hidden gap-5 md:grid md:grid-cols-[minmax(0,380px)_1fr]">
+      <div className="hidden gap-5 md:grid md:grid-cols-[minmax(0,380px)_minmax(0,1fr)]">
         <div>{form}</div>
         <div>{isLoading ? <ListSkeleton /> : list}</div>
       </div>

--- a/app/(protected)/ems/mypage/_components/MyReservations.tsx
+++ b/app/(protected)/ems/mypage/_components/MyReservations.tsx
@@ -137,8 +137,8 @@ export function MyReservations() {
         barEvents,
         matrix,
         isDesktop
-          ? { headH: 26, laneH: 26, minH: 96 }
-          : { headH: 18, laneH: 20, minH: 58 }
+          ? { headH: 26, laneH: 26, minH: 96, maxLanes: 4 }
+          : { headH: 18, laneH: 20, minH: 58, maxLanes: 3 }
       ),
     [barEvents, matrix, isDesktop]
   );
@@ -179,7 +179,7 @@ export function MyReservations() {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-5 md:grid-cols-[1fr_380px] md:items-start">
+    <div className="grid grid-cols-1 gap-5 md:grid-cols-[minmax(0,1fr)_380px] md:items-start">
       {/* 自分の予定カレンダー */}
       <div className="rounded-2xl bg-white p-4 shadow-sm">
         <div className="mb-3 flex items-center justify-between px-1">

--- a/app/(protected)/ems/mypage/_components/MyReservations.tsx
+++ b/app/(protected)/ems/mypage/_components/MyReservations.tsx
@@ -66,8 +66,13 @@ export function MyReservations() {
   const { filteredData, refetch } = useMyReserves({ userId: user?.id });
   const { equipments, isLoading: eqLoading } = useEquipments();
   const { categories } = useCategories();
-  const { pendingId, borrow, giveBack, cancel } = useReserveActions({ refetch });
-  const [cancelTarget, setCancelTarget] = useState<GroupedItem | null>(null);
+  const { pendingIds, borrow, borrowMany, giveBack, giveBackMany, cancel, cancelMany } =
+    useReserveActions({ refetch });
+  // キャンセル確認の対象。単体は items 1件、一括は複数件。
+  const [cancelTarget, setCancelTarget] = useState<{
+    items: GroupedItem[];
+    rangeText: string;
+  } | null>(null);
   const isDesktop = useIsDesktop();
 
   const todayIdx = todayJstDayIndex();
@@ -217,6 +222,19 @@ export function MyReservations() {
                   const active = g.startIdx <= todayIdx && g.endIdx >= todayIdx;
                   const badge = badgeOf(g, todayIdx);
                   const days = g.endIdx - g.startIdx + 1;
+                  const rangeText = formatRange(g.startIdx, g.endIdx);
+                  // 一括操作の対象（2件以上あるときだけグループ操作行を出す）
+                  const borrowables = active
+                    ? g.items.filter((it) => it.isRenting <= 1)
+                    : [];
+                  const returnables = g.items.filter(
+                    (it) => it.isRenting === 2 || it.isRenting === 3
+                  );
+                  const cancellables = g.items.filter((it) => it.isRenting <= 1);
+                  const showBulk =
+                    borrowables.length >= 2 ||
+                    returnables.length >= 2 ||
+                    cancellables.length >= 2;
                   return (
                     <div
                       key={g.key}
@@ -226,7 +244,7 @@ export function MyReservations() {
                       <div className="mb-3 flex items-center gap-2.5">
                         <div className="min-w-0 flex-1">
                           <p className="m-0 text-[15px] font-extrabold">
-                            {formatRange(g.startIdx, g.endIdx)}{" "}
+                            {rangeText}{" "}
                             <span className="text-[11px] font-semibold text-ink-faint">{days}日間</span>
                           </p>
                           <p className="m-0 mt-0.5 text-[11px] text-ink-muted">機材 {g.items.length}件</p>
@@ -238,7 +256,7 @@ export function MyReservations() {
                           const canBorrow = active && it.isRenting <= 1;
                           const canReturn = it.isRenting === 2 || it.isRenting === 3;
                           const canCancel = it.isRenting <= 1;
-                          const pending = pendingId === it.reserveId;
+                          const pending = pendingIds.includes(it.reserveId);
                           return (
                             <div
                               key={it.reserveId}
@@ -280,7 +298,7 @@ export function MyReservations() {
                                 <button
                                   type="button"
                                   disabled={pending}
-                                  onClick={() => setCancelTarget(it)}
+                                  onClick={() => setCancelTarget({ items: [it], rangeText })}
                                   className="h-7 flex-none rounded-lg px-2 text-[11px] font-bold text-danger transition-colors hover:bg-[#FEF3F2] disabled:opacity-50"
                                 >
                                   キャンセル
@@ -290,6 +308,51 @@ export function MyReservations() {
                           );
                         })}
                       </div>
+
+                      {/* 同一期間のまとめて操作（対象が2件以上あるときだけ） */}
+                      {showBulk && (
+                        <div className="mt-2.5 flex items-center gap-1.5 border-t border-line-soft pt-2.5">
+                          <span className="text-[10.5px] font-bold text-ink-faint">
+                            まとめて
+                          </span>
+                          {borrowables.length >= 2 && (
+                            <button
+                              type="button"
+                              disabled={pendingIds.length > 0}
+                              onClick={() =>
+                                borrowMany(borrowables.map((it) => it.reserveId))
+                              }
+                              className="h-7 rounded-lg bg-brand px-2.5 text-[11px] font-bold text-white transition-colors hover:bg-brand-dark disabled:opacity-50"
+                            >
+                              借りる（{borrowables.length}件）
+                            </button>
+                          )}
+                          {returnables.length >= 2 && (
+                            <button
+                              type="button"
+                              disabled={pendingIds.length > 0}
+                              onClick={() =>
+                                giveBackMany(returnables.map((it) => it.reserveId))
+                              }
+                              className="h-7 rounded-lg border-[1.5px] border-brand px-2.5 text-[11px] font-bold text-brand transition-colors hover:bg-brand-faint disabled:opacity-50"
+                            >
+                              返却（{returnables.length}件）
+                            </button>
+                          )}
+                          {cancellables.length >= 2 && (
+                            <button
+                              type="button"
+                              disabled={pendingIds.length > 0}
+                              onClick={() =>
+                                setCancelTarget({ items: cancellables, rangeText })
+                              }
+                              className="h-7 rounded-lg px-2 text-[11px] font-bold text-danger transition-colors hover:bg-[#FEF3F2] disabled:opacity-50"
+                            >
+                              キャンセル（{cancellables.length}件）
+                            </button>
+                          )}
+                        </div>
+                      )}
                     </div>
                   );
                 })}
@@ -310,7 +373,12 @@ export function MyReservations() {
               予約をキャンセルしますか？
             </AlertDialogTitle>
             <AlertDialogDescription className="text-[12.5px]">
-              「{cancelTarget?.name}」の予約を取り消します。この操作は元に戻せません。
+              {cancelTarget?.items.length === 1
+                ? `「${cancelTarget.items[0].name}」の予約を取り消します。`
+                : `${cancelTarget?.rangeText} の予約 ${cancelTarget?.items.length}件（${cancelTarget?.items
+                    .map((it) => it.name)
+                    .join("・")}）を取り消します。`}
+              この操作は元に戻せません。
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -318,7 +386,10 @@ export function MyReservations() {
             <AlertDialogAction
               className="bg-danger hover:bg-danger/90"
               onClick={() => {
-                if (cancelTarget) void cancel(cancelTarget.reserveId);
+                if (cancelTarget) {
+                  const ids = cancelTarget.items.map((it) => it.reserveId);
+                  void (ids.length === 1 ? cancel(ids[0]) : cancelMany(ids));
+                }
                 setCancelTarget(null);
               }}
             >

--- a/app/(protected)/ems/mypage/hooks/use-reserve-actions.test.ts
+++ b/app/(protected)/ems/mypage/hooks/use-reserve-actions.test.ts
@@ -44,7 +44,7 @@ describe("useReserveActions", () => {
       body: JSON.stringify({ isRenting: 2 }),
     });
     expect(refetch).toHaveBeenCalledTimes(1);
-    expect(toastSuccess).toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalledWith("貸し出しを開始しました");
   });
 
   it("giveBack: PATCHes isRenting=4", async () => {
@@ -103,5 +103,75 @@ describe("useReserveActions", () => {
 
     expect(ok).toBe(false);
     expect(toastError).toHaveBeenCalledWith("キャンセルに失敗しました");
+  });
+
+  it("borrowMany: PATCHes every id, toasts the count, refetches once", async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+
+    const { result } = renderHook(() => useReserveActions({ refetch }));
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.borrowMany([1, 2, 3]);
+    });
+
+    expect(ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/reserves/2",
+      expect.objectContaining({ method: "PATCH" })
+    );
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith("3件の貸し出しを開始しました");
+  });
+
+  it("cancelMany: DELETEs every id and toasts the count", async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+
+    const { result } = renderHook(() => useReserveActions({ refetch }));
+    await act(async () => {
+      await result.current.cancelMany([4, 5]);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(toastSuccess).toHaveBeenCalledWith("2件の予約をキャンセルしました");
+  });
+
+  it("giveBackMany: partial failure toasts the fail count, still refetches, returns false", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "貸出中の予約ではありません。" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "貸出中の予約ではありません。" }),
+      } as Response);
+
+    const { result } = renderHook(() => useReserveActions({ refetch }));
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.giveBackMany([1, 2, 3]);
+    });
+
+    expect(ok).toBe(false);
+    expect(toastError).toHaveBeenCalledWith("2件は返却できませんでした");
+    expect(refetch).toHaveBeenCalledTimes(1); // 1件は成功しているので一覧は更新する
+  });
+
+  it("bulk single failure surfaces the API error message verbatim", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "貸出期間外か、すでに貸出中です。" }),
+      } as Response);
+
+    const { result } = renderHook(() => useReserveActions({ refetch }));
+    await act(async () => {
+      await result.current.borrowMany([1, 2]);
+    });
+
+    expect(toastError).toHaveBeenCalledWith("貸出期間外か、すでに貸出中です。");
   });
 });

--- a/app/(protected)/ems/mypage/hooks/use-reserve-actions.ts
+++ b/app/(protected)/ems/mypage/hooks/use-reserve-actions.ts
@@ -7,68 +7,120 @@ export interface UseReserveActionsParams {
   refetch: () => Promise<void>;
 }
 
-// マイ予約カードの操作（借りる / 返却 / キャンセル）。
+// マイ予約カードの操作（借りる / 返却 / キャンセル）。単体と同一期間グループの一括の両方に対応。
 // 借りる・返却は PATCH /api/reserves/[id]（isRenting 遷移）、キャンセルは DELETE。
-// 成否は toast で通知し、成功時は一覧を refetch する。
+// 成否は toast で通知し、1件でも成功したら一覧を refetch する。
 export const useReserveActions = ({ refetch }: UseReserveActionsParams) => {
-  const [pendingId, setPendingId] = useState<number | null>(null);
+  const [pendingIds, setPendingIds] = useState<number[]>([]);
 
-  const patchRenting = async (
-    reserveId: number,
-    isRenting: 2 | 4,
-    okMessage: string
-  ): Promise<boolean> => {
-    setPendingId(reserveId);
+  // 成功なら null、失敗なら表示用のエラーメッセージを返す
+  const patchOne = async (reserveId: number, isRenting: 2 | 4): Promise<string | null> => {
     try {
       const res = await fetch(`/api/reserves/${reserveId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ isRenting }),
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        toast.error(data?.error ?? "操作に失敗しました");
-        return false;
-      }
-      toast.success(okMessage);
-      await refetch();
-      return true;
+      if (res.ok) return null;
+      const data = await res.json().catch(() => null);
+      return data?.error ?? "操作に失敗しました";
     } catch {
-      toast.error("操作に失敗しました");
-      return false;
+      return "操作に失敗しました";
+    }
+  };
+
+  const deleteOne = async (reserveId: number): Promise<string | null> => {
+    try {
+      const res = await fetch(`/api/reserves/${reserveId}`, { method: "DELETE" });
+      if (res.ok) return null;
+      const data = await res.json().catch(() => null);
+      return data?.error ?? "キャンセルに失敗しました";
+    } catch {
+      return "キャンセルに失敗しました";
+    }
+  };
+
+  /**
+   * 複数件を並列実行し、成功/失敗数に応じた toast と refetch をまとめて行う。
+   * 1件だけの失敗は API のエラーメッセージをそのまま出す。全件成功で true。
+   */
+  const runMany = async (
+    reserveIds: number[],
+    run: (id: number) => Promise<string | null>,
+    okMessage: (count: number) => string,
+    failMessage: (count: number) => string
+  ): Promise<boolean> => {
+    if (reserveIds.length === 0) return true;
+    setPendingIds(reserveIds);
+    try {
+      const results = await Promise.all(reserveIds.map((id) => run(id)));
+      const errors = results.filter((r): r is string => r !== null);
+      const okCount = reserveIds.length - errors.length;
+      if (errors.length === 0) {
+        toast.success(okMessage(okCount));
+      } else {
+        toast.error(errors.length === 1 ? errors[0] : failMessage(errors.length));
+      }
+      if (okCount > 0) await refetch();
+      return errors.length === 0;
     } finally {
-      setPendingId(null);
+      setPendingIds([]);
     }
   };
 
   /** 借りる（受取）: isRenting 0|1 → 2 */
   const borrow = (reserveId: number) =>
-    patchRenting(reserveId, 2, "貸し出しを開始しました");
+    runMany(
+      [reserveId],
+      (id) => patchOne(id, 2),
+      () => "貸し出しを開始しました",
+      (n) => `${n}件は貸し出しできませんでした`
+    );
+
+  /** 同一期間グループをまとめて借りる */
+  const borrowMany = (reserveIds: number[]) =>
+    runMany(
+      reserveIds,
+      (id) => patchOne(id, 2),
+      (n) => `${n}件の貸し出しを開始しました`,
+      (n) => `${n}件は貸し出しできませんでした`
+    );
 
   /** 返却: isRenting 2|3 → 4 */
   const giveBack = (reserveId: number) =>
-    patchRenting(reserveId, 4, "返却しました");
+    runMany(
+      [reserveId],
+      (id) => patchOne(id, 4),
+      () => "返却しました",
+      (n) => `${n}件は返却できませんでした`
+    );
+
+  /** 同一期間グループをまとめて返却 */
+  const giveBackMany = (reserveIds: number[]) =>
+    runMany(
+      reserveIds,
+      (id) => patchOne(id, 4),
+      (n) => `${n}件を返却しました`,
+      (n) => `${n}件は返却できませんでした`
+    );
 
   /** 予約キャンセル（削除）。貸出中のものはサーバー側でも拒否される。 */
-  const cancel = async (reserveId: number): Promise<boolean> => {
-    setPendingId(reserveId);
-    try {
-      const res = await fetch(`/api/reserves/${reserveId}`, { method: "DELETE" });
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        toast.error(data?.error ?? "キャンセルに失敗しました");
-        return false;
-      }
-      toast.success("予約をキャンセルしました");
-      await refetch();
-      return true;
-    } catch {
-      toast.error("キャンセルに失敗しました");
-      return false;
-    } finally {
-      setPendingId(null);
-    }
-  };
+  const cancel = (reserveId: number) =>
+    runMany(
+      [reserveId],
+      deleteOne,
+      () => "予約をキャンセルしました",
+      (n) => `${n}件はキャンセルできませんでした`
+    );
 
-  return { pendingId, borrow, giveBack, cancel };
+  /** 同一期間グループをまとめてキャンセル */
+  const cancelMany = (reserveIds: number[]) =>
+    runMany(
+      reserveIds,
+      deleteOne,
+      (n) => `${n}件の予約をキャンセルしました`,
+      (n) => `${n}件はキャンセルできませんでした`
+    );
+
+  return { pendingIds, borrow, borrowMany, giveBack, giveBackMany, cancel, cancelMany };
 };

--- a/components/calendar/MonthGrid.tsx
+++ b/components/calendar/MonthGrid.tsx
@@ -41,11 +41,11 @@ export function MonthGrid<T = unknown>({
             style={{ height: week.height }}
           >
             <div className="grid h-full grid-cols-7">
-              {week.days.map((day) => (
+              {week.days.map((day, colIdx) => (
                 <div
                   key={day.dayIndex}
                   className={cn(
-                    "border-r border-line/60 pt-[3px] text-center text-[10px] last:border-r-0 md:pt-1.5 md:text-[11.5px]",
+                    "relative border-r border-line/60 pt-[3px] text-center text-[10px] last:border-r-0 md:pt-1.5 md:text-[11.5px]",
                     !day.inMonth && "text-line-strong",
                     day.inMonth && !day.isToday && "text-ink-muted",
                     day.isToday && "font-bold text-brand"
@@ -53,6 +53,11 @@ export function MonthGrid<T = unknown>({
                   style={day.isToday ? { background: "#EAF3FE" } : undefined}
                 >
                   {day.dayOfMonth}
+                  {(week.hiddenByCol?.[colIdx] ?? 0) > 0 && (
+                    <span className="absolute bottom-[2px] left-0 right-0 text-[8.5px] font-bold text-ink-faint md:text-[9.5px]">
+                      +{week.hiddenByCol[colIdx]}件
+                    </span>
+                  )}
                 </div>
               ))}
             </div>

--- a/lib/calendar/build-month-weeks.test.ts
+++ b/lib/calendar/build-month-weeks.test.ts
@@ -69,3 +69,46 @@ describe("buildMonthWeeks", () => {
     expect(weeks[1].bars[0].data).toEqual({ who: "蒼" });
   });
 });
+
+describe("buildMonthWeeks: maxLanes（レーン上限）", () => {
+  const matrix = buildMonthMatrix(2024, 11); // 2024年12月
+  const idx = (d: number) => idxOf(2024, 11, d);
+
+  // 12/9(月)〜12/13(金) に同日重なりのイベントを5本
+  const five = (): CalendarBarEvent[] =>
+    Array.from({ length: 5 }, (_, i) => ({
+      key: i + 1,
+      startIdx: idx(9),
+      endIdx: idx(13),
+      color: "#111",
+      label: `E${i + 1}`,
+    }));
+
+  it("上限を超えたバーは隠れ、hiddenByCol に曜日ごとの件数が入る", () => {
+    const weeks = buildMonthWeeks(five(), matrix, {
+      headH: 20, laneH: 20, minH: 40, bottomPad: 4, maxLanes: 3, moreH: 16,
+    });
+    const wk2 = weeks[1];
+    expect(wk2.bars).toHaveLength(3); // 3レーンまで表示
+    expect(wk2.bars.every((b) => b.lane < 3)).toBe(true);
+    // 12/9(月)=col1 〜 12/13(金)=col5 に 2件ずつ隠れる
+    expect(wk2.hiddenByCol).toEqual([0, 2, 2, 2, 2, 2, 0]);
+    // 高さ = headH(20) + 3レーン*20 + moreH(16) + bottomPad(4) = 100（レーン数で無限に伸びない）
+    expect(wk2.height).toBe(100);
+  });
+
+  it("上限未指定なら全バー表示で hiddenByCol は全て 0", () => {
+    const weeks = buildMonthWeeks(five(), matrix, { headH: 20, laneH: 20, minH: 40, bottomPad: 4 });
+    const wk2 = weeks[1];
+    expect(wk2.bars).toHaveLength(5);
+    expect(wk2.hiddenByCol).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(wk2.height).toBe(20 + 5 * 20 + 4);
+  });
+
+  it("隠れバーが無い週には moreH を加算しない", () => {
+    const weeks = buildMonthWeeks(five().slice(0, 2), matrix, {
+      headH: 20, laneH: 20, minH: 40, bottomPad: 4, maxLanes: 3, moreH: 16,
+    });
+    expect(weeks[1].height).toBe(20 + 2 * 20 + 4);
+  });
+});

--- a/lib/calendar/build-month-weeks.ts
+++ b/lib/calendar/build-month-weeks.ts
@@ -30,6 +30,8 @@ export interface WeekRow<T = unknown> {
   days: DayCell[];
   height: number; // px
   bars: PositionedBar<T>[];
+  /** maxLanes 超過で隠れたバーの数（曜日列ごと。上限なしなら全て 0） */
+  hiddenByCol: number[];
 }
 
 export interface BuildOptions {
@@ -38,15 +40,25 @@ export interface BuildOptions {
   minH?: number; // 週の最小高さ（px）
   bottomPad?: number; // 最終レーン下の余白（px）
   gapPct?: number; // バー左右の隙間（%・セル幅比）
+  /**
+   * 週あたりの表示レーン数の上限。超えたバーは非表示にし hiddenByCol に集計する
+   * （実データでは1週に20件以上重なることがあり、無制限だと行高が数百pxに膨らむ）。
+   * 未指定なら無制限。
+   */
+  maxLanes?: number;
+  /** hiddenByCol の「+N」表示行のための追加高さ（px）。隠れバーがある週にだけ加算 */
+  moreH?: number;
 }
 
-const DEFAULTS: Required<BuildOptions> = {
+const DEFAULTS = {
   headH: 22,
   laneH: 22,
   minH: 64,
   bottomPad: 4,
   gapPct: 1.2,
-};
+  maxLanes: Infinity,
+  moreH: 16,
+} satisfies Required<BuildOptions>;
 
 /**
  * events（inclusive な day index 区間）を matrix の各週に配置する。
@@ -72,7 +84,17 @@ export function buildMonthWeeks<T = unknown>(
 
     const { laneCount, laned } = packLanes(segments);
 
-    const bars: PositionedBar<T>[] = laned.map((seg) => {
+    // 上限超過レーンのバーは隠し、曜日列ごとに件数を集計する
+    const hiddenByCol = Array.from({ length: 7 }, () => 0);
+    const visible = laned.filter((seg) => {
+      if (seg.lane < opt.maxLanes) return true;
+      for (let col = seg.startCol; col <= seg.endCol; col++) {
+        hiddenByCol[col] += 1;
+      }
+      return false;
+    });
+
+    const bars: PositionedBar<T>[] = visible.map((seg) => {
       const spanCols = seg.endCol - seg.startCol + 1;
       return {
         key: seg.ev.key,
@@ -88,7 +110,12 @@ export function buildMonthWeeks<T = unknown>(
       };
     });
 
-    const height = Math.max(opt.minH, opt.headH + laneCount * opt.laneH + opt.bottomPad);
-    return { days, height, bars };
+    const shownLanes = Math.min(laneCount, opt.maxLanes);
+    const hasHidden = hiddenByCol.some((n) => n > 0);
+    const height = Math.max(
+      opt.minH,
+      opt.headH + shownLanes * opt.laneH + (hasHidden ? opt.moreH : 0) + opt.bottomPad
+    );
+    return { days, height, bars, hiddenByCol };
   });
 }


### PR DESCRIPTION
## 概要

本番デプロイ後に判明した「カレンダーの表示が大きすぎる」問題の修正と、マイ予約の一括操作機能を含みます。

## カレンダー巨大化の修正（本番データ規模で顕在化）

本番は予約1370件・部員約20人で、dev のシードデータでは再現しなかった2つの問題:

1. **週の行高が無制限に伸びる**: 予約が重なる週はレーン数×26px で行高500px超に。`buildMonthWeeks` にレーン上限（カレンダー: PC6/モバイル4、マイ予約: PC4/モバイル3）を追加し、超過分は日別「**+N件**」表示に集約
2. **PC 2カラムが画面外へはみ出す**: grid の `1fr`（min=auto）が部員チップ行の固有幅（約3500px）まで膨張。全画面の `1fr` を `minmax(0,1fr)` に統一

本番の実データ相当（同一期間9件重複）を dev に再現し、上限表示・「+N件」・行高の安定を実機確認済み。

## マイ予約の一括操作

同じ期間の予約グループに「まとめて 借りる／返却／キャンセル」を追加（対象2件以上のとき表示）。部分失敗時は件数を通知し、一覧は更新。

## 検証

- 313テスト緑・tsc クリーン・本番ビルド成功
- DB migration なし（コード変更のみ）

## マージ後の確認

- [ ] 本番をハードリロード（PWA キャッシュ対策）し、カレンダーの行高と「+N件」表示を確認
- [ ] PC 幅でカードが画面内に収まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138i8BUA1dT8adcyUi32AG1