### PR TITLE
feat: アプリ内フィードバック機能

### DIFF
--- a/app/(protected)/_components/UserMenu.tsx
+++ b/app/(protected)/_components/UserMenu.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { toast } from "sonner";
 import { IoSettingsOutline } from "react-icons/io5";
 import { ExitIcon } from "@radix-ui/react-icons";
 import { HiOutlineWrenchScrewdriver } from "react-icons/hi2";
-import { LuTags, LuMessageCircleQuestion } from "react-icons/lu";
+import { LuTags, LuMessageCircleQuestion, LuMegaphone } from "react-icons/lu";
 import { UserRole } from "@prisma/client";
 
 import {
@@ -39,6 +39,7 @@ function initialOf(name?: string | null) {
 
 export const UserMenu = () => {
   const router = useRouter();
+  const pathname = usePathname();
   const user = useCurrentUser();
   const role = useCurrentRole();
   const isAdmin = role === UserRole.ADMIN;
@@ -47,6 +48,39 @@ export const UserMenu = () => {
   // 運用者への role=ADMIN 付与が整ったら退役する。lib/manager-auth.ts と同じ位置づけ）。
   const [keyDialogOpen, setKeyDialogOpen] = useState(false);
   const [managerKey, setManagerKey] = useState("");
+
+  // アプリ内フィードバック（本文1欄だけの最小ダイアログ。名前・ページは自動付与）
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [feedbackBody, setFeedbackBody] = useState("");
+  const [feedbackSending, setFeedbackSending] = useState(false);
+
+  const onSubmitFeedback = async () => {
+    const body = feedbackBody.trim();
+    if (!body) {
+      toast.error("内容を入力してください");
+      return;
+    }
+    setFeedbackSending(true);
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body, path: pathname }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        toast.error(data?.error ?? "送信に失敗しました");
+        return;
+      }
+      toast.success("フィードバックを送信しました。ありがとうございます！");
+      setFeedbackBody("");
+      setFeedbackOpen(false);
+    } catch {
+      toast.error("送信に失敗しました");
+    } finally {
+      setFeedbackSending(false);
+    }
+  };
 
   const onLogout = () => {
     // logout-button.tsx と同じ理由でクライアント版 signOut を使う
@@ -103,6 +137,10 @@ export const UserMenu = () => {
               <DropdownMenuSeparator />
             </>
           )}
+          <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
+            <LuMegaphone className="mr-2 h-4 w-4" />
+            フィードバックを送る
+          </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <a href={CONTACT_FORM_URL} target="_blank" rel="noopener noreferrer">
               <LuMessageCircleQuestion className="mr-2 h-4 w-4" />
@@ -124,6 +162,35 @@ export const UserMenu = () => {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <Dialog open={feedbackOpen} onOpenChange={setFeedbackOpen}>
+        <DialogContent className="max-w-[400px] rounded-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-[15px]">フィードバックを送る</DialogTitle>
+            <DialogDescription className="text-[12.5px]">
+              不具合・使いにくい点・要望など、気づいたことをそのままどうぞ。
+              開発者にそのまま届きます。
+            </DialogDescription>
+          </DialogHeader>
+          <textarea
+            value={feedbackBody}
+            onChange={(e) => setFeedbackBody(e.target.value)}
+            placeholder="例）予約の画面で◯◯が押しづらい、△△できると嬉しい など"
+            rows={4}
+            maxLength={2000}
+            className="w-full resize-none rounded-xl border-[1.5px] border-line px-3 py-2.5 text-[13.5px] outline-none focus:border-brand"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={onSubmitFeedback}
+            disabled={feedbackSending || feedbackBody.trim().length === 0}
+            className="h-11 w-full rounded-xl bg-brand text-[14px] font-bold text-white transition-colors hover:bg-brand-dark disabled:opacity-50"
+          >
+            {feedbackSending ? "送信中…" : "送信する"}
+          </button>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={keyDialogOpen} onOpenChange={setKeyDialogOpen}>
         <DialogContent className="max-w-[360px] rounded-2xl">

--- a/app/(protected)/dev/feedback/_components/FeedbackList.tsx
+++ b/app/(protected)/dev/feedback/_components/FeedbackList.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+export interface FeedbackItem {
+  id: number;
+  body: string;
+  path: string | null;
+  resolved: boolean;
+  createdAt: string; // ISO
+  userName: string;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function FeedbackList({ initialItems }: { initialItems: FeedbackItem[] }) {
+  const [items, setItems] = useState(initialItems);
+  const [pendingId, setPendingId] = useState<number | null>(null);
+
+  const toggleResolved = async (item: FeedbackItem) => {
+    setPendingId(item.id);
+    try {
+      const res = await fetch(`/api/feedback/${item.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resolved: !item.resolved }),
+      });
+      if (!res.ok) {
+        toast.error("更新に失敗しました");
+        return;
+      }
+      setItems((prev) =>
+        prev.map((it) => (it.id === item.id ? { ...it, resolved: !it.resolved } : it))
+      );
+    } catch {
+      toast.error("更新に失敗しました");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const open = items.filter((it) => !it.resolved);
+  const done = items.filter((it) => it.resolved);
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded-2xl border border-dashed border-line bg-white p-8 text-center text-[13px] text-ink-faint">
+        フィードバックはまだありません
+      </p>
+    );
+  }
+
+  const renderItem = (item: FeedbackItem) => (
+    <div
+      key={item.id}
+      className={cn(
+        "rounded-2xl bg-white p-4 shadow-sm",
+        item.resolved && "opacity-60"
+      )}
+    >
+      <div className="mb-1.5 flex items-center gap-2 text-[11px] text-ink-muted">
+        <span className="font-bold text-ink-sub">{item.userName}</span>
+        <span>{formatDate(item.createdAt)}</span>
+        {item.path && (
+          <span className="rounded bg-line-soft px-1.5 py-0.5 font-mono text-[10px]">
+            {item.path}
+          </span>
+        )}
+        <button
+          type="button"
+          disabled={pendingId === item.id}
+          onClick={() => toggleResolved(item)}
+          className={cn(
+            "ml-auto h-7 flex-none rounded-lg px-2.5 text-[11px] font-bold transition-colors disabled:opacity-50",
+            item.resolved
+              ? "text-ink-muted hover:bg-line-soft"
+              : "border-[1.5px] border-brand text-brand hover:bg-brand-faint"
+          )}
+        >
+          {item.resolved ? "未対応に戻す" : "対応済みにする"}
+        </button>
+      </div>
+      <p className="m-0 whitespace-pre-wrap text-[13.5px] leading-relaxed">{item.body}</p>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section>
+        <p className="mb-2 px-1 text-xs font-bold text-ink-muted">
+          未対応 {open.length}件
+        </p>
+        <div className="flex flex-col gap-2.5">
+          {open.length > 0 ? (
+            open.map(renderItem)
+          ) : (
+            <p className="rounded-2xl bg-white p-5 text-center text-[12.5px] text-ink-faint">
+              未対応はありません 🎉
+            </p>
+          )}
+        </div>
+      </section>
+      {done.length > 0 && (
+        <section>
+          <p className="mb-2 px-1 text-xs font-bold text-ink-muted">
+            対応済み {done.length}件
+          </p>
+          <div className="flex flex-col gap-2.5">{done.map(renderItem)}</div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/(protected)/dev/feedback/page.tsx
+++ b/app/(protected)/dev/feedback/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from "next/navigation";
+import { currentUser } from "@/lib/auth";
+import { isDeveloperEmail } from "@/lib/dev-auth";
+import { db } from "@/lib/db";
+import { FeedbackList } from "./_components/FeedbackList";
+
+// 開発者専用のフィードバック一覧。部長ら運用者の管理画面（/ems/manager 等、ADMIN ゲート）
+// とは別系統で、DEVELOPER_EMAILS に載っている開発者だけが見られる。
+// ナビからのリンクは張らず、URL 直打ちでアクセスする。
+const DevFeedbackPage = async () => {
+  const user = await currentUser();
+  if (!isDeveloperEmail(user?.email)) {
+    notFound();
+  }
+
+  const feedbacks = await db.feedback.findMany({
+    orderBy: [{ resolved: "asc" }, { createdAt: "desc" }],
+    include: { user: { select: { name: true, email: true } } },
+  });
+
+  return (
+    <div className="min-h-full bg-surface">
+      <header className="bg-navy px-4 py-3">
+        <p className="mx-auto max-w-3xl text-[15px] font-black text-white">
+          フィードバック
+          <span className="ml-2 rounded-full bg-white/15 px-2 py-[3px] text-[10px] font-bold">
+            開発者専用
+          </span>
+        </p>
+      </header>
+      <main className="mx-auto max-w-3xl px-4 py-5">
+        <FeedbackList
+          initialItems={feedbacks.map((f) => ({
+            id: f.id,
+            body: f.body,
+            path: f.path,
+            resolved: f.resolved,
+            createdAt: f.createdAt.toISOString(),
+            userName: f.user?.name ?? f.user?.email ?? "退会ユーザー",
+          }))}
+        />
+      </main>
+    </div>
+  );
+};
+
+export default DevFeedbackPage;

--- a/app/api/feedback/[feedbackId]/route.ts
+++ b/app/api/feedback/[feedbackId]/route.ts
@@ -1,0 +1,44 @@
+import { db } from '@/lib/db';
+import { currentUser } from '@/lib/auth';
+import { isDeveloperEmail } from '@/lib/dev-auth';
+import { NextResponse } from 'next/server';
+
+interface Params {
+    params: Promise<{ feedbackId: string }>;
+}
+
+// 対応済みフラグの切り替え。開発者専用。
+export async function PATCH(request: Request, { params }: Params) {
+    try {
+        const user = await currentUser();
+        if (!user?.id) {
+            return NextResponse.json({ error: '認証されていません。' }, { status: 401 });
+        }
+        if (!isDeveloperEmail(user.email)) {
+            return NextResponse.json({ error: '権限がありません。' }, { status: 403 });
+        }
+
+        const feedbackId = parseInt((await params).feedbackId, 10);
+        if (isNaN(feedbackId)) {
+            return NextResponse.json({ error: 'Invalid feedback ID.' }, { status: 400 });
+        }
+
+        const body = await request.json().catch(() => null);
+        if (typeof body?.resolved !== 'boolean') {
+            return NextResponse.json({ error: 'resolved は boolean で指定してください。' }, { status: 400 });
+        }
+
+        const result = await db.feedback.updateMany({
+            where: { id: feedbackId },
+            data: { resolved: body.resolved },
+        });
+        if (result.count === 0) {
+            return NextResponse.json({ error: 'フィードバックが見つかりません。' }, { status: 404 });
+        }
+
+        return NextResponse.json({ message: 'Feedback updated.' }, { status: 200 });
+    } catch (error) {
+        console.error('Error updating feedback:', error);
+        return NextResponse.json({ error: 'Failed to update feedback.' }, { status: 500 });
+    }
+}

--- a/app/api/feedback/route.test.ts
+++ b/app/api/feedback/route.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createMock, findManyMock, currentUserMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  findManyMock: vi.fn(),
+  currentUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { feedback: { create: createMock, findMany: findManyMock } },
+}));
+vi.mock("@/lib/auth", () => ({
+  currentUser: () => currentUserMock(),
+}));
+
+import { GET, POST } from "./route";
+
+const postRequest = (body: unknown) =>
+  new Request("http://localhost/api/feedback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  createMock.mockReset();
+  findManyMock.mockReset();
+  currentUserMock.mockReset();
+  vi.stubEnv("DEVELOPER_EMAILS", "dev@example.com");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("POST /api/feedback", () => {
+  it("returns 401 when unauthenticated", async () => {
+    currentUserMock.mockResolvedValue(undefined);
+
+    const res = await POST(postRequest({ body: "使いにくい" }));
+
+    expect(res.status).toBe(401);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("creates feedback with the session user's id (body from client is not trusted for userId)", async () => {
+    currentUserMock.mockResolvedValue({ id: "u1", email: "member@example.com" });
+    createMock.mockResolvedValue({ id: 1 });
+
+    const res = await POST(postRequest({ body: "予約画面の◯◯が押しづらい", path: "/ems/mypage" }));
+
+    expect(res.status).toBe(201);
+    expect(createMock).toHaveBeenCalledWith({
+      data: { userId: "u1", body: "予約画面の◯◯が押しづらい", path: "/ems/mypage" },
+    });
+  });
+
+  it("rejects an empty body with 400", async () => {
+    currentUserMock.mockResolvedValue({ id: "u1", email: "member@example.com" });
+
+    const res = await POST(postRequest({ body: "   " }));
+
+    expect(res.status).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body over 2000 chars with 400", async () => {
+    currentUserMock.mockResolvedValue({ id: "u1", email: "member@example.com" });
+
+    const res = await POST(postRequest({ body: "あ".repeat(2001) }));
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/feedback", () => {
+  it("returns 403 for a non-developer (even ADMIN operators)", async () => {
+    currentUserMock.mockResolvedValue({ id: "u1", email: "president@example.com", role: "ADMIN" });
+
+    const res = await GET();
+
+    expect(res.status).toBe(403);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the list for a developer email", async () => {
+    currentUserMock.mockResolvedValue({ id: "u1", email: "dev@example.com" });
+    findManyMock.mockResolvedValue([{ id: 1, body: "test", resolved: false }]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(findManyMock).toHaveBeenCalled();
+  });
+
+  it("returns 403 for everyone when DEVELOPER_EMAILS is unset", async () => {
+    vi.stubEnv("DEVELOPER_EMAILS", "");
+    currentUserMock.mockResolvedValue({ id: "u1", email: "dev@example.com" });
+
+    const res = await GET();
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,60 @@
+import { db } from '@/lib/db';
+import { currentUser } from '@/lib/auth';
+import { isDeveloperEmail } from '@/lib/dev-auth';
+import { FeedbackSchema } from '@/schemas';
+import { NextResponse } from 'next/server';
+
+// フィードバック送信。ログイン部員なら誰でも。
+export async function POST(request: Request) {
+    try {
+        const user = await currentUser();
+        if (!user?.id) {
+            return NextResponse.json({ error: '認証されていません。' }, { status: 401 });
+        }
+
+        const data = await request.json().catch(() => null);
+        const parsed = FeedbackSchema.safeParse(data);
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: parsed.error.issues[0]?.message ?? '入力内容が不正です。' },
+                { status: 400 }
+            );
+        }
+
+        const feedback = await db.feedback.create({
+            data: {
+                userId: user.id,
+                body: parsed.data.body,
+                path: parsed.data.path ?? null,
+            },
+        });
+
+        return NextResponse.json({ id: feedback.id }, { status: 201 });
+    } catch (error) {
+        console.error('Error creating feedback:', error);
+        return NextResponse.json({ error: 'Failed to create feedback.' }, { status: 500 });
+    }
+}
+
+// フィードバック一覧。開発者専用（部長向け ADMIN とは別ゲート）。
+export async function GET() {
+    try {
+        const user = await currentUser();
+        if (!user?.id) {
+            return NextResponse.json({ error: '認証されていません。' }, { status: 401 });
+        }
+        if (!isDeveloperEmail(user.email)) {
+            return NextResponse.json({ error: '権限がありません。' }, { status: 403 });
+        }
+
+        const feedbacks = await db.feedback.findMany({
+            orderBy: [{ resolved: 'asc' }, { createdAt: 'desc' }],
+            include: { user: { select: { name: true, email: true } } },
+        });
+
+        return NextResponse.json(feedbacks, { status: 200 });
+    } catch (error) {
+        console.error('Error fetching feedbacks:', error);
+        return NextResponse.json({ error: 'Failed to fetch feedbacks.' }, { status: 500 });
+    }
+}

--- a/lib/dev-auth.ts
+++ b/lib/dev-auth.ts
@@ -1,0 +1,16 @@
+/**
+ * 開発者判定。フィードバック閲覧など「開発者専用」機能のゲートに使う。
+ *
+ * 部長ら運用者の role=ADMIN（管理画面ゲート）とは別系統:
+ * ADMIN は機材・カテゴリの運用者、DEVELOPER_EMAILS はシステム開発者。
+ * 環境変数 DEVELOPER_EMAILS にカンマ区切りでメールアドレスを列挙する
+ * （ローカルは .env、本番は wrangler.jsonc の vars）。未設定なら誰も通らない。
+ */
+export const isDeveloperEmail = (email: string | null | undefined): boolean => {
+  if (!email) return false;
+  const allow = (process.env.DEVELOPER_EMAILS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return allow.includes(email.toLowerCase());
+};

--- a/prisma/migrations/20260706023114_add_feedback/migration.sql
+++ b/prisma/migrations/20260706023114_add_feedback/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "feedback" (
+    "id" SERIAL NOT NULL,
+    "user_id" TEXT,
+    "body" TEXT NOT NULL,
+    "path" TEXT,
+    "resolved" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "feedback_resolved_created_at_idx" ON "feedback"("resolved", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "feedback" ADD CONSTRAINT "feedback_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,24 @@ model User {
   isTwoFactorEnabled Boolean @default(false)
   twoFactorConfirmation TwoFactorConfirmation?
   settings      UserSettings?
+  feedbacks     Feedback[]
 
   @@map("users")
+}
+
+// 部員からのアプリ内フィードバック（ユーザーメニューの1タップ送信）。
+// 閲覧は開発者専用ページ /dev/feedback（部長向け管理画面とは別系統）。
+model Feedback {
+  id        Int      @id @default(autoincrement())
+  userId    String?  @map("user_id")
+  user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  body      String
+  path      String?  // 送信元ページ（自動付与）
+  resolved  Boolean  @default(false)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([resolved, createdAt])
+  @@map("feedback")
 }
 
 enum CalendarView {

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -75,3 +75,11 @@ export const RegisterSchema = z.object({
         message: "名前を入力してください"
     })
 })
+export const FeedbackSchema = z.object({
+    body: z.string().trim().min(1, {
+        message: "内容を入力してください"
+    }).max(2000, {
+        message: "2000文字以内で入力してください"
+    }),
+    path: z.string().max(200).optional(),
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,7 +28,9 @@
     "AUTH_TRUST_HOST": "true",
     "R2_PUBLIC_BASE_URL": "https://images.abs-ems.forgeonics.com",
     // lib/mail.ts が実行時に読む（リセット/確認メールのリンク生成）
-    "NEXT_PUBLIC_APP_URL": "https://abs-ems.forgeonics.com"
+    "NEXT_PUBLIC_APP_URL": "https://abs-ems.forgeonics.com",
+    // 開発者専用機能（/dev/feedback 閲覧など）のゲート。カンマ区切り（lib/dev-auth.ts）
+    "DEVELOPER_EMAILS": "daichi8120@gmail.com"
   },
   // 機材画像の保存先（Phase 2 で使用）。binding 名はコード側の識別子で任意。
   "r2_buckets": [


### PR DESCRIPTION
## 概要

部員が負担なくフィードバックを送れる機能を追加します。

## 送る側（部員）

- ユーザーメニューに「フィードバックを送る」→ **本文1欄だけ**のダイアログ → 送信
- 送信者・送信元ページは自動付与（入力は本文のみ）

## 見る側（開発者専用）

- `/dev/feedback` — 未対応/対応済みに分けて一覧、トグルで切り替え
- **部長ら運用者の管理画面（ADMIN ゲート）とは別系統**: `DEVELOPER_EMAILS` 環境変数（wrangler vars に設定済み: daichi8120@gmail.com）のメールだけが閲覧可。ナビには載せず URL 直アクセス
- 非開発者は 404 / API は 403

## DB migration（マージで CI が本番適用）

- `20260706023114_add_feedback` — feedback テーブル追加（DDL のみ・既存データ影響なし）

## 検証

- 送信 → 一覧表示 → 対応済みトグル → 未対応に戻す、まで dev 実機で一通り確認
- 320テスト緑（API テスト7件追加）・tsc クリーン・本番ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138i8BUA1dT8adcyUi32AG1