### PR TITLE
本番反映: メール通知配信 ＋ Web Analytics トークン更新

### DIFF
--- a/app/api/cron/return-reminders/route.test.ts
+++ b/app/api/cron/return-reminders/route.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findManyMock, updateMock, notifyReturnReminderMock } = vi.hoisted(() => ({
+  findManyMock: vi.fn(),
+  updateMock: vi.fn(),
+  notifyReturnReminderMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { reserve: { findMany: findManyMock, update: updateMock } },
+}));
+vi.mock("@/lib/notify", () => ({
+  notifyReturnReminder: notifyReturnReminderMock,
+}));
+
+import { GET } from "./route";
+
+const req = (auth?: string) =>
+  new Request("http://localhost/api/cron/return-reminders", {
+    headers: auth ? { authorization: auth } : {},
+  });
+
+const prevSecret = process.env.CRON_SECRET;
+
+beforeEach(() => {
+  findManyMock.mockReset();
+  updateMock.mockReset().mockResolvedValue({});
+  notifyReturnReminderMock.mockReset().mockResolvedValue(undefined);
+  process.env.CRON_SECRET = "s3cret";
+});
+afterEach(() => {
+  process.env.CRON_SECRET = prevSecret;
+});
+
+describe("GET /api/cron/return-reminders", () => {
+  it("rejects requests without the correct secret", async () => {
+    const res = await GET(req("Bearer wrong"));
+    expect(res.status).toBe(401);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when CRON_SECRET is unset", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(req("Bearer s3cret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("notifies each due reserve and marks it reminded", async () => {
+    findManyMock.mockResolvedValue([
+      { id: 1, user_id: "u1", list_id: 10, start: null, end: new Date("2026-07-06T00:00:00Z") },
+      { id: 2, user_id: "u2", list_id: 11, start: null, end: new Date("2026-07-06T00:00:00Z") },
+    ]);
+
+    const res = await GET(req("Bearer s3cret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(notifyReturnReminderMock).toHaveBeenCalledTimes(2);
+    expect(updateMock).toHaveBeenCalledTimes(2);
+    expect(body).toMatchObject({ targeted: 2, sent: 2, failed: 0 });
+  });
+
+  it("keeps going when one send fails and reports the failure count", async () => {
+    findManyMock.mockResolvedValue([
+      { id: 1, user_id: "u1", list_id: 10, start: null, end: new Date("2026-07-06T00:00:00Z") },
+      { id: 2, user_id: "u2", list_id: 11, start: null, end: new Date("2026-07-06T00:00:00Z") },
+    ]);
+    notifyReturnReminderMock.mockRejectedValueOnce(new Error("send failed"));
+
+    const res = await GET(req("Bearer s3cret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ targeted: 2, sent: 1, failed: 1 });
+    // 失敗した1件は reminded_on を更新しない（翌回の再送を許す）。
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/cron/return-reminders/route.ts
+++ b/app/api/cron/return-reminders/route.ts
@@ -1,0 +1,57 @@
+import { db } from '@/lib/db';
+import { notifyReturnReminder } from '@/lib/notify';
+import { NextResponse } from 'next/server';
+import moment from 'moment-timezone';
+
+/* 返却期限リマインダー（cron から叩かれる内部エンドポイント）。
+ *
+ * 呼び出し元は worker.ts の scheduled ハンドラ（Cloudflare Cron Trigger）。
+ * 外部から叩かれないよう CRON_SECRET（wrangler secret）で保護する。
+ *
+ * 返却期限（Reserve.end）が本日（JST）で、まだ貸出中(2)・滞納(3)＝未返却の予約を対象に、
+ * 持ち主へ「本日返却期限」を通知する。同日の二重送信は reminded_on で弾く。
+ */
+
+export async function GET(request: Request) {
+    const secret = process.env.CRON_SECRET;
+    const auth = request.headers.get('authorization');
+    if (!secret || auth !== `Bearer ${secret}`) {
+        return NextResponse.json({ error: '権限がありません。' }, { status: 401 });
+    }
+
+    try {
+        // 保存値は「JST 日付の UTC 00:00」。今日(JST)も同じ座標系に変換して等値比較する。
+        const todayJst = new Date(moment().tz('Asia/Tokyo').format('YYYY-MM-DD') + 'T00:00:00Z');
+
+        const reserves = await db.reserve.findMany({
+            where: {
+                end: todayJst,
+                isRenting: { in: [2, 3] },
+                user_id: { not: null },
+                // 本日分をまだ送っていないものだけ（cron 二重発火・再試行に対する冪等性）。
+                OR: [{ remindedOn: null }, { remindedOn: { not: todayJst } }],
+            },
+        });
+
+        // 1件の失敗が全体を止めないよう allSettled。成功したものだけ reminded_on を更新する。
+        const results = await Promise.allSettled(
+            reserves.map(async (r) => {
+                await notifyReturnReminder(r);
+                await db.reserve.update({
+                    where: { id: r.id },
+                    data: { remindedOn: todayJst },
+                });
+            }),
+        );
+
+        const sent = results.filter((x) => x.status === 'fulfilled').length;
+        const failed = results.length - sent;
+        if (failed > 0) {
+            console.error(`return-reminders: ${failed}/${results.length} 件の送信に失敗しました。`);
+        }
+        return NextResponse.json({ targeted: reserves.length, sent, failed }, { status: 200 });
+    } catch (error) {
+        console.error('Error sending return reminders:', error);
+        return NextResponse.json({ error: 'Failed to send reminders.' }, { status: 500 });
+    }
+}

--- a/app/api/lists/route.ts
+++ b/app/api/lists/route.ts
@@ -1,6 +1,7 @@
 import { db } from '@/lib/db';
 import { hasManagerAccess } from '@/lib/api-auth';
 import { currentUser } from '@/lib/auth';
+import { notifyInBackground, notifyNewEquipment } from '@/lib/notify';
 import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
@@ -13,7 +14,7 @@ export async function POST(request: Request) {
 
         const { name, detail, image, tag_id } = data;
 
-        await db.list.create({
+        const created = await db.list.create({
             data: {
                 name: name,
                 detail: detail,
@@ -22,6 +23,9 @@ export async function POST(request: Request) {
                 tag_id: tag_id,
             },
         });
+
+        // 新機材の追加を notifyNewEquipment 有効な部員へ一斉通知（レスポンスは待たせない）。
+        notifyInBackground(notifyNewEquipment(created));
 
         return new Response(JSON.stringify({ message: 'データが正常に追加されました。' }), {
             status: 201,

--- a/app/api/reserves/[reserveId]/route.test.ts
+++ b/app/api/reserves/[reserveId]/route.test.ts
@@ -1,20 +1,28 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { deleteManyMock, updateManyMock, findManyMock, findFirstMock, currentUserMock } =
-  vi.hoisted(() => ({
-    deleteManyMock: vi.fn(),
-    updateManyMock: vi.fn(),
-    findManyMock: vi.fn(),
-    findFirstMock: vi.fn(),
-    currentUserMock: vi.fn(),
-  }));
+const {
+  deleteManyMock,
+  updateManyMock,
+  findManyMock,
+  findFirstMock,
+  findUniqueMock,
+  currentUserMock,
+} = vi.hoisted(() => ({
+  deleteManyMock: vi.fn(),
+  updateManyMock: vi.fn(),
+  findManyMock: vi.fn(),
+  findFirstMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+  currentUserMock: vi.fn(),
+}));
 
 vi.mock("@/lib/db", () => ({
   db: {
     reserve: {
       findMany: findManyMock,
       findFirst: findFirstMock,
+      findUnique: findUniqueMock,
       deleteMany: deleteManyMock,
       updateMany: updateManyMock,
     },
@@ -22,6 +30,12 @@ vi.mock("@/lib/db", () => ({
 }));
 vi.mock("@/lib/auth", () => ({
   currentUser: () => currentUserMock(),
+}));
+
+// 通知はバックグラウンド副作用なので、ルートの契約テストでは無効化する。
+vi.mock("@/lib/notify", () => ({
+  notifyInBackground: vi.fn(),
+  notifyReservationCancelled: vi.fn(),
 }));
 
 import { DELETE, GET, PATCH } from "./route";
@@ -42,6 +56,7 @@ beforeEach(() => {
   updateManyMock.mockReset();
   findManyMock.mockReset();
   findFirstMock.mockReset();
+  findUniqueMock.mockReset();
   currentUserMock.mockReset();
 });
 

--- a/app/api/reserves/[reserveId]/route.ts
+++ b/app/api/reserves/[reserveId]/route.ts
@@ -1,5 +1,6 @@
 import { db } from '@/lib/db';
 import { currentUser } from '@/lib/auth';
+import { notifyInBackground, notifyReservationCancelled } from '@/lib/notify';
 import { UserRole } from '@prisma/client';
 import { NextResponse } from 'next/server';
 import moment from 'moment-timezone';
@@ -117,6 +118,8 @@ export async function DELETE(request: Request, { params }: Params) {
         // 一般部員は未貸出（0:予約中/1:受取可）のみキャンセル可。貸出中(2)・滞納(3)・
         // 返却済(4)の記録は消せない（旧UIのクライアント側ルールをサーバーに移植）。
         const isAdmin = user.role === UserRole.ADMIN;
+        // 管理者が他人の予約を取り消したとき持ち主へ通知するため、削除前に対象を控える。
+        const target = await db.reserve.findUnique({ where: { id: reserveId } });
         const result = await db.reserve.deleteMany({
             where: isAdmin
                 ? { id: reserveId }
@@ -134,6 +137,11 @@ export async function DELETE(request: Request, { params }: Params) {
                 );
             }
             return NextResponse.json({ error: '予約が見つかりません。' }, { status: 404 });
+        }
+
+        // 管理者が他人の予約を取り消した場合のみ、持ち主へメール通知（本人の自己取消は通知しない）。
+        if (target?.user_id && target.user_id !== user.id) {
+            notifyInBackground(notifyReservationCancelled(target));
         }
 
         return NextResponse.json({ message: 'Reserve deleted successfully.' }, { status: 200 });

--- a/app/api/reserves/route.test.ts
+++ b/app/api/reserves/route.test.ts
@@ -25,6 +25,12 @@ vi.mock("@/lib/auth", () => ({
   currentUser: currentUserMock,
 }));
 
+// 通知はバックグラウンド副作用なので、ルートの契約テストでは無効化する。
+vi.mock("@/lib/notify", () => ({
+  notifyInBackground: vi.fn(),
+  notifyReservationCreated: vi.fn(),
+}));
+
 import { GET, POST } from "./route";
 
 const postRequest = (body: Record<string, unknown>) =>

--- a/app/api/reserves/route.ts
+++ b/app/api/reserves/route.ts
@@ -1,5 +1,6 @@
 import { db } from '@/lib/db';
 import { currentUser } from '@/lib/auth';
+import { notifyInBackground, notifyReservationCreated } from '@/lib/notify';
 import { NextResponse } from 'next/server';
 import moment from 'moment-timezone';
 
@@ -136,6 +137,9 @@ export async function POST(request: Request) {
         if (result.conflict) {
             return NextResponse.json({ error: 'この期間にはすでに予約が入っています。' }, { status: 409 });
         }
+
+        // 予約確定を本人へメール通知（notifyReservationEvents 尊重）。レスポンスは待たせない。
+        notifyInBackground(notifyReservationCreated(result.reserve));
 
         return NextResponse.json(result.reserve, { status: 201 });
     } catch (error) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,13 +43,14 @@ export default async function RootLayout({
           <Toaster />
           {children}
           {/* Cloudflare Web Analytics（旧 Vercel Speed Insights の代替）。
-              token は全訪問者に配る公開値（ダッシュボードのサイト設定と対応）。
+              token は全訪問者に配る公開値（forgeonics.com ゾーン連携サイトのもの。
+              ホスト名手入力で作ったサイトの token は ingest 側で有効化されず 503 になる）。
               beacon は SPA のルート遷移も自動計測する。next dev では読み込まない。 */}
           {process.env.NODE_ENV === "production" && (
             <Script
               strategy="afterInteractive"
               src="https://static.cloudflareinsights.com/beacon.min.js"
-              data-cf-beacon='{"token": "c1b5d038f286402eb590a0a7dd180c43"}'
+              data-cf-beacon='{"token": "4da583fec5f34da4bbbd3346ff51db8a"}'
             />
           )}
         </body>

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -36,6 +36,10 @@ declare global {
   interface CloudflareEnv {
     IMAGES_BUCKET: AbsEmsR2Bucket;
     EMAIL: AbsEmsSendEmail;
+    // worker.ts の scheduled ハンドラが内部 cron エンドポイントを叩くときに使う。
+    // AUTH_URL は wrangler.jsonc の vars、CRON_SECRET は wrangler secret で投入。
+    AUTH_URL?: string;
+    CRON_SECRET?: string;
   }
 }
 

--- a/lib/notify.test.ts
+++ b/lib/notify.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendMock, waitUntilMock, getCtxMock, userFindUniqueMock, listFindUniqueMock, userSettingsFindManyMock } =
+  vi.hoisted(() => ({
+    sendMock: vi.fn(),
+    waitUntilMock: vi.fn(),
+    getCtxMock: vi.fn(),
+    userFindUniqueMock: vi.fn(),
+    listFindUniqueMock: vi.fn(),
+    userSettingsFindManyMock: vi.fn(),
+  }));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => getCtxMock(),
+}));
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: { findUnique: userFindUniqueMock },
+    list: { findUnique: listFindUniqueMock },
+    userSettings: { findMany: userSettingsFindManyMock },
+  },
+}));
+
+import {
+  formatReserveDate,
+  notifyUser,
+  notifyInBackground,
+  notifyNewEquipment,
+} from "./notify";
+
+const okCtx = () => ({ env: { EMAIL: { send: sendMock } }, ctx: { waitUntil: waitUntilMock } });
+
+beforeEach(() => {
+  sendMock.mockReset().mockResolvedValue({ messageId: "m1" });
+  waitUntilMock.mockReset();
+  getCtxMock.mockReset().mockReturnValue(okCtx());
+  userFindUniqueMock.mockReset();
+  listFindUniqueMock.mockReset();
+  userSettingsFindManyMock.mockReset();
+});
+
+describe("formatReserveDate", () => {
+  it("formats the stored UTC-midnight date as its JST calendar date", () => {
+    expect(formatReserveDate(new Date("2026-07-06T00:00:00Z"))).toBe("2026/07/06");
+  });
+  it("returns a dash for null", () => {
+    expect(formatReserveDate(null)).toBe("-");
+  });
+});
+
+describe("notifyUser", () => {
+  const msg = { subject: "s", html: "<p>h</p>", text: "t" };
+
+  it("sends when the matching toggle is enabled", async () => {
+    userFindUniqueMock.mockResolvedValue({
+      email: "a@example.com",
+      settings: { notifyReturnReminder: true, notifyReservationEvents: true, notifyNewEquipment: false },
+    });
+
+    await notifyUser("u1", "reservationEvents", msg);
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][0]).toMatchObject({ to: "a@example.com", subject: "s" });
+  });
+
+  it("does not send when the matching toggle is disabled", async () => {
+    userFindUniqueMock.mockResolvedValue({
+      email: "a@example.com",
+      settings: { notifyReturnReminder: true, notifyReservationEvents: false, notifyNewEquipment: false },
+    });
+
+    await notifyUser("u1", "reservationEvents", msg);
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to defaults when no settings row exists (events default true)", async () => {
+    userFindUniqueMock.mockResolvedValue({ email: "a@example.com", settings: null });
+
+    await notifyUser("u1", "reservationEvents", msg);
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips newEquipment by default when no settings row exists", async () => {
+    userFindUniqueMock.mockResolvedValue({ email: "a@example.com", settings: null });
+
+    await notifyUser("u1", "newEquipment", msg);
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("skips users without an email", async () => {
+    userFindUniqueMock.mockResolvedValue({ email: null, settings: null });
+
+    await notifyUser("u1", "returnReminder", msg);
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("notifyNewEquipment", () => {
+  it("sends to every opted-in member with an email", async () => {
+    userSettingsFindManyMock.mockResolvedValue([
+      { user: { email: "a@example.com" } },
+      { user: { email: "b@example.com" } },
+    ]);
+
+    await notifyNewEquipment({ name: "新カメラ" });
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("notifyInBackground", () => {
+  it("swallows task rejection and never throws", async () => {
+    getCtxMock.mockImplementation(() => {
+      throw new Error("no cloudflare context");
+    });
+    const rejecting = Promise.reject(new Error("boom"));
+
+    expect(() => notifyInBackground(rejecting)).not.toThrow();
+    // マイクロタスクを流して未処理拒否が起きないことを確認
+    await Promise.resolve();
+  });
+
+  it("uses ctx.waitUntil when the Cloudflare context is present", () => {
+    notifyInBackground(Promise.resolve());
+    expect(waitUntilMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,0 +1,181 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { db } from "@/lib/db";
+
+/* アプリ通知の配信層。
+ *
+ * 現状はメールのみ（Cloudflare Email Sending バインディング。lib/mail.ts と同じ経路）。
+ * LINE は将来 UserSettings.lineNotifyEnabled && lineUserId で push を足す想定で、
+ * ここに「継ぎ目」だけ用意しておく（今は未実装。ユーザー判断で保留）。
+ *
+ * 通知の種類は UserSettings のトグルに対応する:
+ *   - returnReminder    → notifyReturnReminder    返却期限リマインダー（cron）
+ *   - reservationEvents → notifyReservationEvents 予約の確定・（管理者による）取消
+ *   - newEquipment      → notifyNewEquipment      新しい機材の追加
+ * UserSettings 行が無いユーザーは schema のデフォルト（reminder/events=true, newEquipment=false）に従う。
+ *
+ * getCloudflareContext() は「関数内で」呼ぶ（Workers ランタイムでのみ有効。lib/mail.ts 参照）。
+ */
+
+const FROM = { email: "noreply@abs-ems.forgeonics.com", name: "ABS EMS" };
+
+/**
+ * 通知をリクエストのバックグラウンドで実行する（レスポンスを待たせない）。
+ * Workers では ctx.waitUntil に載せてレスポンス後も走らせる。
+ * Cloudflare コンテキストが無い環境（next dev / テスト）や送信失敗でも
+ * 呼び出し元（予約作成など）を巻き込まないよう、必ず握りつぶす（通知はベストエフォート）。
+ */
+export function notifyInBackground(task: Promise<void>): void {
+  const guarded = task.catch((e) => {
+    console.error("notify failed:", e);
+  });
+  try {
+    const { ctx } = getCloudflareContext();
+    ctx.waitUntil(guarded);
+  } catch {
+    // ctx 不在（Workers ランタイム外）。fire-and-forget にフォールバック。
+  }
+}
+
+export type NotifyKind = "returnReminder" | "reservationEvents" | "newEquipment";
+
+const KIND_TO_SETTING = {
+  returnReminder: "notifyReturnReminder",
+  reservationEvents: "notifyReservationEvents",
+  newEquipment: "notifyNewEquipment",
+} as const;
+
+// UserSettings 行が無いときの既定値（schema の @default と一致させる）。
+const KIND_DEFAULT: Record<NotifyKind, boolean> = {
+  returnReminder: true,
+  reservationEvents: true,
+  newEquipment: false,
+};
+
+interface MailContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+// 低レベル送信。宛先アドレスへメールを1通送る（設定チェックはしない）。
+async function sendMail(to: string, msg: MailContent): Promise<void> {
+  const { env } = getCloudflareContext();
+  await env.EMAIL.send({ from: FROM, to, ...msg });
+}
+
+/**
+ * 単一ユーザーへ通知する。UserSettings のトグルを尊重し、無効なら何もしない。
+ * メールアドレス未登録のユーザーもスキップ。例外は握りつぶさず呼び出し側に伝える
+ * （cron/waitUntil 側で allSettled / catch する）。
+ */
+export async function notifyUser(
+  userId: string,
+  kind: NotifyKind,
+  msg: MailContent,
+): Promise<void> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      email: true,
+      settings: {
+        select: {
+          notifyReturnReminder: true,
+          notifyReservationEvents: true,
+          notifyNewEquipment: true,
+        },
+      },
+    },
+  });
+  if (!user?.email) return;
+
+  const enabled = user.settings
+    ? user.settings[KIND_TO_SETTING[kind]]
+    : KIND_DEFAULT[kind];
+  if (!enabled) return;
+
+  // TODO(LINE): ここで settings?.lineNotifyEnabled && lineUserId のとき LINE push を足す。
+  await sendMail(user.email, msg);
+}
+
+// start/end は「JST 日付の UTC 00:00」保存。UTC ゲッタで JST 日付をそのまま整形する。
+export function formatReserveDate(d: Date | null | undefined): string {
+  if (!d) return "-";
+  const y = d.getUTCFullYear();
+  const m = `${d.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getUTCDate()}`.padStart(2, "0");
+  return `${y}/${m}/${day}`;
+}
+
+async function listName(listId: number | null | undefined): Promise<string> {
+  if (listId == null) return "機材";
+  const list = await db.list.findUnique({ where: { id: listId }, select: { name: true } });
+  return list?.name ?? "機材";
+}
+
+type ReserveLike = {
+  user_id: string | null;
+  list_id: number | null;
+  start: Date | null;
+  end: Date | null;
+};
+
+const APP_URL = () => process.env.NEXT_PUBLIC_APP_URL ?? "https://abs-ems.forgeonics.com";
+
+// 予約が確定したことを本人へ知らせる（予約作成時）。
+export async function notifyReservationCreated(reserve: ReserveLike): Promise<void> {
+  if (!reserve.user_id) return;
+  const name = await listName(reserve.list_id);
+  const period = `${formatReserveDate(reserve.start)} 〜 ${formatReserveDate(reserve.end)}`;
+  await notifyUser(reserve.user_id, "reservationEvents", {
+    subject: `予約を受け付けました（${name}）`,
+    html: `<p>${name} の予約を受け付けました。</p><p>利用期間: ${period}</p><p><a href="${APP_URL()}/ems/mypage">マイ予約を開く</a></p>`,
+    text: `${name} の予約を受け付けました。\n利用期間: ${period}\nマイ予約: ${APP_URL()}/ems/mypage`,
+  });
+}
+
+// 管理者が他人の予約を取り消したことを、予約の持ち主へ知らせる。
+export async function notifyReservationCancelled(reserve: ReserveLike): Promise<void> {
+  if (!reserve.user_id) return;
+  const name = await listName(reserve.list_id);
+  const period = `${formatReserveDate(reserve.start)} 〜 ${formatReserveDate(reserve.end)}`;
+  await notifyUser(reserve.user_id, "reservationEvents", {
+    subject: `予約が取り消されました（${name}）`,
+    html: `<p>${name} の予約（${period}）が管理者によって取り消されました。</p><p>心当たりがない場合は部の管理者にご確認ください。</p>`,
+    text: `${name} の予約（${period}）が管理者によって取り消されました。\n心当たりがない場合は部の管理者にご確認ください。`,
+  });
+}
+
+// 返却期限当日のリマインダー（cron から呼ぶ）。
+export async function notifyReturnReminder(reserve: ReserveLike): Promise<void> {
+  if (!reserve.user_id) return;
+  const name = await listName(reserve.list_id);
+  await notifyUser(reserve.user_id, "returnReminder", {
+    subject: `本日返却期限です（${name}）`,
+    html: `<p>${name} の返却期限は本日（${formatReserveDate(reserve.end)}）です。</p><p>部室で返却手続きをお願いします。</p><p><a href="${APP_URL()}/ems/mypage">マイ予約を開く</a></p>`,
+    text: `${name} の返却期限は本日（${formatReserveDate(reserve.end)}）です。\n部室で返却手続きをお願いします。\nマイ予約: ${APP_URL()}/ems/mypage`,
+  });
+}
+
+/**
+ * 新しい機材の追加を、notifyNewEquipment を有効にしている部員へ一斉配信する。
+ * 1件の失敗が全体を止めないよう allSettled。設定行のあるユーザーだけが対象
+ * （newEquipment の既定は false なので、明示的に true にした人のみ）。
+ */
+export async function notifyNewEquipment(list: { name: string | null }): Promise<void> {
+  const targets = await db.userSettings.findMany({
+    where: { notifyNewEquipment: true, user: { email: { not: null } } },
+    select: { user: { select: { email: true } } },
+  });
+  const name = list.name ?? "新しい機材";
+  const msg: MailContent = {
+    subject: `新しい機材が追加されました（${name}）`,
+    html: `<p>新しい機材「${name}」が追加されました。</p><p><a href="${APP_URL()}/ems/equipment-list">予約する</a></p>`,
+    text: `新しい機材「${name}」が追加されました。\n予約する: ${APP_URL()}/ems/equipment-list`,
+  };
+  await Promise.allSettled(
+    targets
+      .map((t) => t.user?.email)
+      .filter((e): e is string => !!e)
+      .map((email) => sendMail(email, msg)),
+  );
+}

--- a/prisma/migrations/20260706100000_add_reserve_reminded_on/migration.sql
+++ b/prisma/migrations/20260706100000_add_reserve_reminded_on/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Reserve" ADD COLUMN "reminded_on" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,9 @@ model Reserve {
   end       DateTime?
   list_id   Int?
   isRenting Int? @default(0)
+  // 返却リマインダー（cron）の二重送信防止。最後に通知した「返却期限日」を
+  // JST 日付の UTC 00:00 で記録する。cron が同日に複数回発火してもこの列で弾く。
+  remindedOn DateTime? @map("reminded_on")
 
   // POST の重複(期間重なり)チェック route.ts の findFirst({ list_id, start<=E, end>=S }) と
   // ?list_id= フィルタに効く。等値 list_id を先頭、範囲 start を第2列に。

--- a/worker.ts
+++ b/worker.ts
@@ -1,0 +1,27 @@
+/* Cloudflare Workers のカスタムエントリ。
+ *
+ * OpenNext(@opennextjs/cloudflare) が生成する worker は fetch ハンドラしか持たないため、
+ * Cron Trigger（返却リマインダー）用の scheduled ハンドラをここで足す。
+ * 生成 worker の fetch はそのまま再利用する（wrangler.jsonc の main をこのファイルに向ける）。
+ *
+ * .open-next/worker.js はビルド時（opennextjs-cloudflare build）に生成されるので、
+ * 型チェック時点では存在しないことがある。生成物の有無で挙動が変わらないよう
+ * @ts-ignore で握る（@ts-expect-error は生成物が残っていると「未使用」で失敗する）。
+ */
+// @ts-ignore .open-next/worker.js はビルド時に生成される
+import worker from './.open-next/worker.js';
+
+type ExecutionCtx = { waitUntil(p: Promise<unknown>): void };
+
+export default {
+  ...worker,
+  async scheduled(_event: { cron: string }, env: CloudflareEnv, ctx: ExecutionCtx) {
+    const base = env.AUTH_URL ?? 'https://abs-ems.forgeonics.com';
+    const req = new Request(`${base}/api/cron/return-reminders`, {
+      headers: { authorization: `Bearer ${env.CRON_SECRET ?? ''}` },
+    });
+    // 生成 worker の fetch に内部リクエストを渡し、Next.js ランタイム内でルートを実行する
+    // （Prisma / EMAIL バインディング / lib をそのまま再利用できる）。
+    ctx.waitUntil(worker.fetch(req, env, ctx));
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,9 @@
   // ビルドは `opennextjs-cloudflare build` が .open-next/ を生成する。
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "abs-ems",
-  "main": ".open-next/worker.js",
+  // カスタムエントリ（worker.ts）。OpenNext 生成の .open-next/worker.js(fetch) を再利用しつつ
+  // scheduled ハンドラ（返却リマインダー cron）を足すため、既定の .open-next/worker.js から差し替え。
+  "main": "worker.ts",
   // nodejs_compat: node:crypto 等（jose/bcrypt/Prisma）に必要
   // compatibility_date は FinalizationRegistry(>=2025-05-05) と process.env 反映のため新しめに
   "compatibility_date": "2025-05-05",
@@ -50,6 +52,11 @@
       "allowed_sender_addresses": ["noreply@abs-ems.forgeonics.com"]
     }
   ],
+  // 返却リマインダー cron。00:00 UTC = 09:00 JST に毎日発火し、worker.ts の scheduled が
+  // /api/cron/return-reminders を叩く。保護用の CRON_SECRET は `wrangler secret put CRON_SECRET` で投入。
+  "triggers": {
+    "crons": ["0 0 * * *"]
+  },
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
develop に溜まった2件を本番へ反映する。main への push で CI（`prisma migrate deploy` → `opennextjs-cloudflare build` → `wrangler deploy`）が走る。

## 含まれる変更
1. **メール通知配信（フェーズ6・メールのみ / LINE 保留）** — merge fe2323d
   - `lib/notify.ts`（Cloudflare Email Sending、UserSettings の3トグル尊重、`notifyInBackground`）
   - 返却リマインダー: `worker.ts`（カスタムエントリで scheduled 追加）→ 内部 `/api/cron/return-reminders`（`CRON_SECRET` 保護）。cron `0 0 * * *`（09:00 JST）。二重送信は `Reserve.remindedOn`（migration `20260706100000`）で防止
   - 予約イベント（確定/管理者取消）・新機材の waitUntil 駆動通知
2. **Web Analytics トークン更新** — merge 0b36289（ゾーン連携サイトの新 token）

## マージ前に必要（本番シークレット）
- [ ] `echo "<ランダム値>" | npx wrangler secret put CRON_SECRET` を実行済みであること（未設定だと cron は毎回 401 で何もしない）

## マージで自動実行される（CI）
- migration `20260706100000_add_reserve_reminded_on`（`ALTER TABLE "Reserve" ADD COLUMN "reminded_on"`）が本番に適用される
- `main` = worker.ts（カスタムエントリ）＋ cron トリガーが登録される

## 反映後の確認
- Cloudflare のログ（observability 有効）で翌 09:00 JST の cron 実行と `/api/cron/return-reminders` の結果（`{targeted, sent, failed}`）を確認
- 予約作成/管理者取消/新機材追加でメールが届くか

## 前提
- 任意宛先へのメール配信は Workers **有料プラン**で有効（確認済み）。2FA/リセットと同じ Email Sending 経路

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsaTYLCSZKySu7Sso3DqJQ