### PR TITLE
UI改善: カレンダー全件表示・機材画像・部員チップ・Web Analyticsトークン

### DIFF
--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -77,8 +77,8 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         barEvents,
         matrix,
         isDesktop
-          ? { headH: 26, laneH: 26, minH: 104, maxLanes: 6 }
-          : { headH: 20, laneH: 20, minH: 62, maxLanes: 4 }
+          ? { headH: 26, laneH: 26, minH: 104 }
+          : { headH: 20, laneH: 20, minH: 62 }
       ),
     [barEvents, matrix, isDesktop]
   );

--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import {
   useCalendarData,
@@ -44,16 +44,29 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
   const [viewYear, setViewYear] = useState(todayDate.getFullYear());
   const [viewMonth0, setViewMonth0] = useState(todayDate.getMonth());
 
-  const members = useMemo(() => {
-    const set = new Set<string>();
-    allEvents.forEach((e) => e.name && set.add(e.name));
-    return [...set];
-  }, [allEvents]);
-
   const matrix = useMemo(
     () => buildMonthMatrix(viewYear, viewMonth0),
     [viewYear, viewMonth0]
   );
+
+  // 絞り込みチップは「表示中の月グリッドに予約が掛かる部員」だけに絞る
+  // （全期間の部員を並べるとチップが縦に膨らむうえ、選んでも何も起きない）。
+  const gridStartIdx = matrix.weeks[0][0].dayIndex;
+  const gridEndIdx = matrix.weeks[matrix.weeks.length - 1][6].dayIndex;
+  const members = useMemo(() => {
+    const set = new Set<string>();
+    allEvents.forEach((e) => {
+      if (!e.name) return;
+      const { startIdx, endIdx } = eventInterval(e);
+      if (endIdx >= gridStartIdx && startIdx <= gridEndIdx) set.add(e.name);
+    });
+    return [...set];
+  }, [allEvents, gridStartIdx, gridEndIdx]);
+
+  // 月を移動して選択中の部員がいなくなったら「すべて」に戻す
+  useEffect(() => {
+    if (memberFilter != null && !members.includes(memberFilter)) setMemberFilter(null);
+  }, [members, memberFilter]);
 
   const barEvents = useMemo<CalendarBarEvent<CalendarEvent>[]>(
     () =>

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -170,7 +170,7 @@ export function BookingWizard() {
       <div className="mx-auto max-w-md">
         <DoneScreen
           doneText={`${rangeText} に ${cartItems.length}件の機材を予約しました`}
-          onToCalendar={() => router.push("/ems/common")}
+          onToMyPage={() => router.push("/ems/mypage")}
           onRestart={restart}
         />
       </div>

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -18,6 +18,7 @@ import {
   dayIndexToDateString,
 } from "@/lib/calendar/date-grid";
 import { categoryColor, categoryIconPath } from "@/lib/category-colors";
+import { flattenNewlines } from "@/lib/text";
 import type { DayRange } from "@/components/calendar/RangeMiniCalendar";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -85,7 +86,7 @@ export function BookingWizard() {
             return {
               id: e.id,
               name: e.name,
-              detail: e.detail ?? "",
+              detail: flattenNewlines(e.detail ?? ""),
               image: e.image ?? "",
               free,
               sub: free

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -86,6 +86,7 @@ export function BookingWizard() {
               id: e.id,
               name: e.name,
               detail: e.detail ?? "",
+              image: e.image ?? "",
               free,
               sub: free
                 ? "この期間は空いています"
@@ -113,6 +114,7 @@ export function BookingWizard() {
         return {
           id,
           name: e?.name ?? "",
+          image: e?.image ?? "",
           color,
           iconPath: categoryIconPath(cat?.name),
         };

--- a/app/(protected)/ems/equipment-list/_components/ConfirmPanel.tsx
+++ b/app/(protected)/ems/equipment-list/_components/ConfirmPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { tint } from "@/lib/category-colors";
 import type { CartItem } from "./types";
 
@@ -38,14 +39,20 @@ export function ConfirmPanel({
         ) : (
           cartItems.map((c) => (
             <div key={c.id} className="flex items-center gap-2.5 rounded-xl bg-surface px-3 py-2">
-              <span
-                className="flex h-[38px] w-[38px] flex-none items-center justify-center rounded-[10px]"
-                style={{ background: tint(c.color) }}
-              >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={c.color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-                  <path d={c.iconPath} />
-                </svg>
-              </span>
+              {c.image ? (
+                <span className="relative h-[38px] w-[38px] flex-none overflow-hidden rounded-[10px] bg-white">
+                  <Image src={c.image} alt="" fill sizes="38px" className="object-cover" unoptimized />
+                </span>
+              ) : (
+                <span
+                  className="flex h-[38px] w-[38px] flex-none items-center justify-center rounded-[10px]"
+                  style={{ background: tint(c.color) }}
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={c.color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                    <path d={c.iconPath} />
+                  </svg>
+                </span>
+              )}
               <span className="flex-1 truncate text-[13.5px] font-bold">{c.name}</span>
               <button
                 type="button"

--- a/app/(protected)/ems/equipment-list/_components/DoneScreen.tsx
+++ b/app/(protected)/ems/equipment-list/_components/DoneScreen.tsx
@@ -3,11 +3,11 @@
 // 予約完了画面。
 export function DoneScreen({
   doneText,
-  onToCalendar,
+  onToMyPage,
   onRestart,
 }: {
   doneText: string;
-  onToCalendar: () => void;
+  onToMyPage: () => void;
   onRestart: () => void;
 }) {
   return (
@@ -21,10 +21,10 @@ export function DoneScreen({
       <p className="m-0 mb-6 text-[13px] text-ink-muted">{doneText}</p>
       <button
         type="button"
-        onClick={onToCalendar}
+        onClick={onToMyPage}
         className="mb-2.5 h-12 w-full rounded-xl bg-navy text-[14.5px] font-bold text-white"
       >
-        カレンダーで確認する
+        マイ予約で確認する
       </button>
       <button
         type="button"

--- a/app/(protected)/ems/equipment-list/_components/EquipmentPickPanel.tsx
+++ b/app/(protected)/ems/equipment-list/_components/EquipmentPickPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { tint } from "@/lib/category-colors";
 import type { PickGroup } from "./types";
@@ -58,14 +59,20 @@ export function EquipmentPickPanel({
                     </svg>
                   )}
                 </span>
-                <span
-                  className="flex h-[52px] w-[52px] flex-none items-center justify-center rounded-xl"
-                  style={{ background: tint(g.color) }}
-                >
-                  <svg width="27" height="27" viewBox="0 0 24 24" fill="none" stroke={g.color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-                    <path d={g.iconPath} />
-                  </svg>
-                </span>
+                {it.image ? (
+                  <span className="relative h-[52px] w-[52px] flex-none overflow-hidden rounded-xl bg-surface">
+                    <Image src={it.image} alt="" fill sizes="52px" className="object-cover" unoptimized />
+                  </span>
+                ) : (
+                  <span
+                    className="flex h-[52px] w-[52px] flex-none items-center justify-center rounded-xl"
+                    style={{ background: tint(g.color) }}
+                  >
+                    <svg width="27" height="27" viewBox="0 0 24 24" fill="none" stroke={g.color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                      <path d={g.iconPath} />
+                    </svg>
+                  </span>
+                )}
                 <span className="min-w-0 flex-1">
                   <span className="block text-sm font-bold">{it.name}</span>
                   <span className="mt-0.5 block text-[11.5px] leading-snug text-ink-muted line-clamp-2">

--- a/app/(protected)/ems/equipment-list/_components/types.ts
+++ b/app/(protected)/ems/equipment-list/_components/types.ts
@@ -3,6 +3,7 @@ export interface PickItem {
   id: number;
   name: string;
   detail: string;
+  image: string; // 機材写真のURL。空ならカテゴリアイコンで代替
   free: boolean;
   sub: string; // 「この期間は空いています」/「M/D〜M/D ○○が予約」
   selected: boolean;
@@ -19,6 +20,7 @@ export interface PickGroup {
 export interface CartItem {
   id: number;
   name: string;
+  image: string; // 機材写真のURL。空ならカテゴリアイコンで代替
   color: string;
   iconPath: string;
 }

--- a/app/(protected)/ems/mypage/_components/MyReservations.tsx
+++ b/app/(protected)/ems/mypage/_components/MyReservations.tsx
@@ -137,8 +137,8 @@ export function MyReservations() {
         barEvents,
         matrix,
         isDesktop
-          ? { headH: 26, laneH: 26, minH: 96, maxLanes: 4 }
-          : { headH: 18, laneH: 20, minH: 58, maxLanes: 3 }
+          ? { headH: 26, laneH: 26, minH: 96 }
+          : { headH: 18, laneH: 20, minH: 58 }
       ),
     [barEvents, matrix, isDesktop]
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,7 @@ export default async function RootLayout({
             <Script
               strategy="afterInteractive"
               src="https://static.cloudflareinsights.com/beacon.min.js"
-              data-cf-beacon='{"token": "4da583fec5f34da4bbbd3346ff51db8a"}'
+              data-cf-beacon='{"token": "d7af9ef8eb544c439b12d40727bbaa74"}'
             />
           )}
         </body>

--- a/components/calendar/MemberChips.tsx
+++ b/components/calendar/MemberChips.tsx
@@ -1,18 +1,30 @@
 "use client";
 
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { memberColor, memberInitial } from "@/lib/calendar/member-colors";
 
 // 月カレンダーの部員絞り込みチップ。「すべて」+ 各部員。選択中の部員以外のバーを
 // 呼び出し側で淡色化する（value===null で全表示）。
+// 人数が多い月はスマホで縦に膨らむため、上限を超えたら折りたたみ「他N人」で展開する。
 export interface MemberChipsProps {
   members: string[]; // 部員名の一覧
   value: string | null; // 選択中の部員名（null = すべて）
   onChange: (name: string | null) => void;
   className?: string;
+  /** 折りたたみ時に表示するチップ数の上限（「すべて」を含む。おおよそ2行分） */
+  collapseLimit?: number;
 }
 
-export function MemberChips({ members, value, onChange, className }: MemberChipsProps) {
+export function MemberChips({
+  members,
+  value,
+  onChange,
+  className,
+  collapseLimit = 10,
+}: MemberChipsProps) {
+  const [expanded, setExpanded] = useState(false);
+
   const items: { name: string | null; label: string; initial: string; color: string }[] = [
     { name: null, label: "すべて", initial: "全", color: "#475467" },
     ...members.map((name) => ({
@@ -23,9 +35,20 @@ export function MemberChips({ members, value, onChange, className }: MemberChips
     })),
   ];
 
+  const overflow = items.length > collapseLimit;
+  let shown = items;
+  if (overflow && !expanded) {
+    shown = items.slice(0, collapseLimit);
+    // 選択中の部員が折りたたみで隠れると「何で絞っているか」が見えなくなるので末尾に足す
+    if (value != null && !shown.some((it) => it.name === value)) {
+      const selected = items.find((it) => it.name === value);
+      if (selected) shown = [...shown, selected];
+    }
+  }
+
   return (
     <div className={cn("flex flex-wrap gap-1.5", className)}>
-      {items.map((it) => {
+      {shown.map((it) => {
         const on = value === it.name;
         return (
           <button
@@ -49,6 +72,15 @@ export function MemberChips({ members, value, onChange, className }: MemberChips
           </button>
         );
       })}
+      {overflow && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex h-8 flex-none items-center rounded-full border border-dashed border-line-strong bg-white px-3 text-[11.5px] font-bold text-ink-muted"
+        >
+          {expanded ? "折りたたむ" : `他${items.length - shown.length}人`}
+        </button>
+      )}
     </div>
   );
 }

--- a/components/calendar/MemberChips.tsx
+++ b/components/calendar/MemberChips.tsx
@@ -24,7 +24,7 @@ export function MemberChips({ members, value, onChange, className }: MemberChips
   ];
 
   return (
-    <div className={cn("flex gap-1.5 overflow-x-auto", className)}>
+    <div className={cn("flex flex-wrap gap-1.5", className)}>
       {items.map((it) => {
         const on = value === it.name;
         return (

--- a/components/calendar/MonthGrid.tsx
+++ b/components/calendar/MonthGrid.tsx
@@ -41,7 +41,7 @@ export function MonthGrid<T = unknown>({
             style={{ height: week.height }}
           >
             <div className="grid h-full grid-cols-7">
-              {week.days.map((day, colIdx) => (
+              {week.days.map((day) => (
                 <div
                   key={day.dayIndex}
                   className={cn(
@@ -53,11 +53,6 @@ export function MonthGrid<T = unknown>({
                   style={day.isToday ? { background: "#EAF3FE" } : undefined}
                 >
                   {day.dayOfMonth}
-                  {(week.hiddenByCol?.[colIdx] ?? 0) > 0 && (
-                    <span className="absolute bottom-[2px] left-0 right-0 text-[8.5px] font-bold text-ink-faint md:text-[9.5px]">
-                      +{week.hiddenByCol[colIdx]}件
-                    </span>
-                  )}
                 </div>
               ))}
             </div>

--- a/lib/calendar/build-month-weeks.test.ts
+++ b/lib/calendar/build-month-weeks.test.ts
@@ -70,7 +70,7 @@ describe("buildMonthWeeks", () => {
   });
 });
 
-describe("buildMonthWeeks: maxLanes（レーン上限）", () => {
+describe("buildMonthWeeks: 高密度週（省略なし）", () => {
   const matrix = buildMonthMatrix(2024, 11); // 2024年12月
   const idx = (d: number) => idxOf(2024, 11, d);
 
@@ -84,31 +84,12 @@ describe("buildMonthWeeks: maxLanes（レーン上限）", () => {
       label: `E${i + 1}`,
     }));
 
-  it("上限を超えたバーは隠れ、hiddenByCol に曜日ごとの件数が入る", () => {
-    const weeks = buildMonthWeeks(five(), matrix, {
-      headH: 20, laneH: 20, minH: 40, bottomPad: 4, maxLanes: 3, moreH: 16,
-    });
-    const wk2 = weeks[1];
-    expect(wk2.bars).toHaveLength(3); // 3レーンまで表示
-    expect(wk2.bars.every((b) => b.lane < 3)).toBe(true);
-    // 12/9(月)=col1 〜 12/13(金)=col5 に 2件ずつ隠れる
-    expect(wk2.hiddenByCol).toEqual([0, 2, 2, 2, 2, 2, 0]);
-    // 高さ = headH(20) + 3レーン*20 + moreH(16) + bottomPad(4) = 100（レーン数で無限に伸びない）
-    expect(wk2.height).toBe(100);
-  });
-
-  it("上限未指定なら全バー表示で hiddenByCol は全て 0", () => {
+  it("重なりが多くても全バー表示し、週の高さがレーン数に応じて伸びる", () => {
     const weeks = buildMonthWeeks(five(), matrix, { headH: 20, laneH: 20, minH: 40, bottomPad: 4 });
     const wk2 = weeks[1];
     expect(wk2.bars).toHaveLength(5);
-    expect(wk2.hiddenByCol).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    const lanes = wk2.bars.map((b) => b.lane).sort();
+    expect(lanes).toEqual([0, 1, 2, 3, 4]);
     expect(wk2.height).toBe(20 + 5 * 20 + 4);
-  });
-
-  it("隠れバーが無い週には moreH を加算しない", () => {
-    const weeks = buildMonthWeeks(five().slice(0, 2), matrix, {
-      headH: 20, laneH: 20, minH: 40, bottomPad: 4, maxLanes: 3, moreH: 16,
-    });
-    expect(weeks[1].height).toBe(20 + 2 * 20 + 4);
   });
 });

--- a/lib/calendar/build-month-weeks.ts
+++ b/lib/calendar/build-month-weeks.ts
@@ -1,5 +1,7 @@
 // 月グリッド + イベントを「週ごとの配置済みバー」に変換する（純関数）。
 // UI刷新案の buildMyWeeks を一般化。MonthGrid / マイ予約カレンダーの両方から使う。
+// バーは省略せず全件配置し、週の高さはレーン数に応じて伸びる
+// （以前は maxLanes で「+N件」に丸めていたが、全件見える方を優先する判断に変更）。
 
 import type { DayCell, MonthMatrix } from "./date-grid";
 import { clipToWeek, packLanes } from "./lane-packing";
@@ -30,8 +32,6 @@ export interface WeekRow<T = unknown> {
   days: DayCell[];
   height: number; // px
   bars: PositionedBar<T>[];
-  /** maxLanes 超過で隠れたバーの数（曜日列ごと。上限なしなら全て 0） */
-  hiddenByCol: number[];
 }
 
 export interface BuildOptions {
@@ -40,14 +40,6 @@ export interface BuildOptions {
   minH?: number; // 週の最小高さ（px）
   bottomPad?: number; // 最終レーン下の余白（px）
   gapPct?: number; // バー左右の隙間（%・セル幅比）
-  /**
-   * 週あたりの表示レーン数の上限。超えたバーは非表示にし hiddenByCol に集計する
-   * （実データでは1週に20件以上重なることがあり、無制限だと行高が数百pxに膨らむ）。
-   * 未指定なら無制限。
-   */
-  maxLanes?: number;
-  /** hiddenByCol の「+N」表示行のための追加高さ（px）。隠れバーがある週にだけ加算 */
-  moreH?: number;
 }
 
 const DEFAULTS = {
@@ -56,8 +48,6 @@ const DEFAULTS = {
   minH: 64,
   bottomPad: 4,
   gapPct: 1.2,
-  maxLanes: Infinity,
-  moreH: 16,
 } satisfies Required<BuildOptions>;
 
 /**
@@ -84,17 +74,7 @@ export function buildMonthWeeks<T = unknown>(
 
     const { laneCount, laned } = packLanes(segments);
 
-    // 上限超過レーンのバーは隠し、曜日列ごとに件数を集計する
-    const hiddenByCol = Array.from({ length: 7 }, () => 0);
-    const visible = laned.filter((seg) => {
-      if (seg.lane < opt.maxLanes) return true;
-      for (let col = seg.startCol; col <= seg.endCol; col++) {
-        hiddenByCol[col] += 1;
-      }
-      return false;
-    });
-
-    const bars: PositionedBar<T>[] = visible.map((seg) => {
+    const bars: PositionedBar<T>[] = laned.map((seg) => {
       const spanCols = seg.endCol - seg.startCol + 1;
       return {
         key: seg.ev.key,
@@ -110,12 +90,7 @@ export function buildMonthWeeks<T = unknown>(
       };
     });
 
-    const shownLanes = Math.min(laneCount, opt.maxLanes);
-    const hasHidden = hiddenByCol.some((n) => n > 0);
-    const height = Math.max(
-      opt.minH,
-      opt.headH + shownLanes * opt.laneH + (hasHidden ? opt.moreH : 0) + opt.bottomPad
-    );
-    return { days, height, bars, hiddenByCol };
+    const height = Math.max(opt.minH, opt.headH + laneCount * opt.laneH + opt.bottomPad);
+    return { days, height, bars };
   });
 }

--- a/lib/text.test.ts
+++ b/lib/text.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { flattenNewlines } from "./text";
+
+describe("flattenNewlines", () => {
+  it("実際の改行を空白1つに畳む", () => {
+    expect(flattenNewlines("1行目\n2行目\r\n3行目")).toBe("1行目 2行目 3行目");
+  });
+
+  it("文字どおりの「\\n」(バックスラッシュ+n)も畳む", () => {
+    expect(flattenNewlines("apture 600dです\\n色温度はいじれません")).toBe(
+      "apture 600dです 色温度はいじれません"
+    );
+  });
+
+  it("連続する改行は空白1つにまとめ、端の改行は取り除く", () => {
+    expect(flattenNewlines("小型照明3つがセットです\\n\\n2800K-6500K")).toBe(
+      "小型照明3つがセットです 2800K-6500K"
+    );
+    expect(flattenNewlines("NANLITE FS-300Bです。\\n")).toBe("NANLITE FS-300Bです。");
+  });
+
+  it("「\\n」以外のバックスラッシュ列はそのまま残す", () => {
+    expect(flattenNewlines("Vマウントバッテリーです\\99のやつです")).toBe(
+      "Vマウントバッテリーです\\99のやつです"
+    );
+  });
+});

--- a/lib/text.ts
+++ b/lib/text.ts
@@ -1,0 +1,9 @@
+// 短い行数で表示する説明文向けのテキスト整形。
+
+/**
+ * 改行を空白1つへ畳む。実際の改行(\r\n / \r / \n)に加えて、旧登録フォーム由来で
+ * 文字どおりの「\n」(バックスラッシュ+n) が保存されているデータがあるため、両方を対象にする。
+ */
+export function flattenNewlines(text: string): string {
+  return text.replace(/(?:\r\n|[\r\n]|\\n)+/g, " ").trim();
+}


### PR DESCRIPTION
## 概要

UI/UXの改善5件をまとめて本番へ反映する。

### カレンダー
- **「+N件」省略を廃止し全件表示**: `buildMonthWeeks` の `maxLanes`/`hiddenByCol` を撤去。週の行高がレーン数に応じて伸び、全予約バーが見える（共有カレンダー・マイ予約とも）
- **部員絞り込みチップの改善**: 横スクロールをやめ折り返し表示に。チップは「表示中の月に予約がある部員」だけに絞り、10個超は折りたたんで「他N人」で展開。月移動で選択部員が不在になったら「すべて」へ戻す

### 予約ウィザード
- **機材画像を表示**: 機材選択リスト(Step2)とカート(Step3)のサムネイルを、カテゴリアイコンから機材写真(`List.image`)優先に変更。未登録時はアイコンにフォールバック
- **説明文の改行を整形**: 旧フォーム由来の文字どおりの「\n」と実改行を空白へ畳む `flattenNewlines` を追加
- **予約完了後の導線変更**: 「カレンダーで確認する」→「マイ予約で確認する」(`/ems/mypage`)へ

### その他
- Web Analyticsトークンをゾーン連携で再作成したサイトの値へ更新

## 補足
- migration の追加なし（CI の本番 migrate は no-op）
- テスト: 336件 all green / `tsc --noEmit` エラーなし
- 本番機材「センチュリー1」のみ画像未登録のためアイコン表示のまま（管理画面から写真登録で解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQKp4tERqX2DTEr7daJSnx