### PR TITLE
リリース: UI/パフォーマンスレビュー対応（検証済み60件の改善）

### DIFF
--- a/actions/login.test.ts
+++ b/actions/login.test.ts
@@ -229,7 +229,7 @@ describe("login - signIn errors", () => {
     vi.mocked(signIn).mockRejectedValue(new MockAuthError("Verification"));
 
     const result = await login({ email: "a@b.com", password: "anything" });
-    expect(result).toEqual({ error: "something went wrong!" });
+    expect(result).toEqual({ error: "エラーが発生しました。時間をおいて再度お試しください。" });
   });
 
   it("re-throws non-AuthError errors", async () => {

--- a/actions/login.ts
+++ b/actions/login.ts
@@ -115,7 +115,7 @@ export const login = async (
                 case "CredentialsSignin":
                     return { error: "Emailかパスワードに間違いがあります！" }
                 default:
-                    return { error: "something went wrong!" }
+                    return { error: "エラーが発生しました。時間をおいて再度お試しください。" }
             }
         }
 

--- a/app/(protected)/ems/_components/EquipmentForm.tsx
+++ b/app/(protected)/ems/_components/EquipmentForm.tsx
@@ -47,12 +47,27 @@ export function EquipmentForm({
 }) {
   const shownImage = previewUrl || existingImageUrl || "";
 
+  // 文言どおり PC からのドラッグ&ドロップを受け付ける。preventDefault しないと
+  // ブラウザが画像ファイルそのものを開いてページ遷移し、入力途中の内容が全部消える。
+  const handleDrop = (e: React.DragEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.type.startsWith("image/") || !inputFileRef.current) return;
+    // input.files へ流し込み、既存の onChange 経路（プレビュー生成・送信時参照）を再利用する
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    inputFileRef.current.files = dt.files;
+    inputFileRef.current.dispatchEvent(new Event("change", { bubbles: true }));
+  };
+
   return (
     <div className="rounded-2xl bg-white p-4 shadow-sm">
       <p className="m-0 mb-2 text-xs font-bold text-ink-muted">機材の写真</p>
       <button
         type="button"
         onClick={() => inputFileRef.current?.click()}
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
         className="relative flex h-[180px] w-full items-center justify-center overflow-hidden rounded-[14px] border-[1.5px] border-dashed border-line-strong bg-surface text-[13px] text-ink-faint"
       >
         {shownImage ? (

--- a/app/(protected)/ems/_components/EquipmentForm.tsx
+++ b/app/(protected)/ems/_components/EquipmentForm.tsx
@@ -84,7 +84,9 @@ export function EquipmentForm({
         className="hidden"
       />
 
-      <p className="m-0 mb-2 mt-4 text-xs font-bold text-ink-muted">カテゴリ</p>
+      <p className="m-0 mb-2 mt-4 text-xs font-bold text-ink-muted">
+        カテゴリ <RequiredBadge />
+      </p>
       <div className="flex flex-wrap gap-1.5">
         {categories.map((c) => {
           const on = selectedTagName === c.name;
@@ -110,7 +112,9 @@ export function EquipmentForm({
         })}
       </div>
 
-      <p className="m-0 mb-2 mt-4 text-xs font-bold text-ink-muted">機材名</p>
+      <p className="m-0 mb-2 mt-4 text-xs font-bold text-ink-muted">
+        機材名 <RequiredBadge />
+      </p>
       <input
         value={name}
         onChange={(e) => onName(e.target.value)}
@@ -134,6 +138,24 @@ export function EquipmentForm({
       >
         {isSubmitting ? "処理中…" : submitLabel}
       </button>
+      {/* ボタンが押せない理由を明示する（灰色のまま理由が分からない状態を防ぐ） */}
+      {!canSubmit && !isSubmitting && (
+        <p className="m-0 mt-2 text-center text-[11.5px] text-ink-faint">
+          {name.trim() === "" && selectedTagName === ""
+            ? "機材名の入力とカテゴリの選択が必要です"
+            : name.trim() === ""
+              ? "機材名を入力してください"
+              : "カテゴリを選択してください"}
+        </p>
+      )}
     </div>
+  );
+}
+
+function RequiredBadge() {
+  return (
+    <span className="ml-0.5 rounded bg-[#FEF3F2] px-1 py-px text-[10px] font-bold text-danger">
+      必須
+    </span>
   );
 }

--- a/app/(protected)/ems/_hooks/use-equipments.test.ts
+++ b/app/(protected)/ems/_hooks/use-equipments.test.ts
@@ -1,10 +1,13 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useEquipments } from "./use-equipments";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/_hooks/use-equipments.test.ts
+++ b/app/(protected)/ems/_hooks/use-equipments.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 
 describe("useEquipments", () => {
   it("starts with empty equipments and isLoading=true", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useEquipments());
     expect(result.current.equipments).toEqual([]);
     expect(result.current.isLoading).toBe(true);
@@ -26,7 +26,7 @@ describe("useEquipments", () => {
 
   it("fetches /api/lists on mount and sorts by name", async () => {
     fetchMock.mockResolvedValue({
-      json: async () => [
+      ok: true, json: async () => [
         { id: 1, name: "Tripod", detail: "", image: "", tag_id: "1" },
         { id: 2, name: "Camera", detail: "", image: "", tag_id: "1" },
         { id: 3, name: "Mic", detail: "", image: "", tag_id: "1" },
@@ -44,7 +44,7 @@ describe("useEquipments", () => {
   });
 
   it("refetch re-runs the fetch", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useEquipments());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -58,7 +58,7 @@ describe("useEquipments", () => {
   it("resolves the spinner and stays empty on a non-array (401/500) body", async () => {
     // /api/lists が認証ゲートで {error} を返しても .sort でハングせず、
     // 無限スピナーにならないことを固定（本来の不変条件）
-    fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ error: "認証されていません。" }) });
 
     const { result } = renderHook(() => useEquipments());
 

--- a/app/(protected)/ems/_hooks/use-equipments.ts
+++ b/app/(protected)/ems/_hooks/use-equipments.ts
@@ -1,31 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 import type { Equipment } from "@/types/domain";
 
+// 機材一覧。キャッシュはタブ切り替え（再マウント）時に前回データを即表示し、
+// 裏で再取得する（use-cached-endpoint 参照）。
 export const useEquipments = () => {
-  const [equipments, setEquipments] = useState<Equipment[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  const refetch = async () => {
-    try {
-      const response = await fetch("/api/lists");
-      const data = await response.json();
-      // 非配列ボディ(401/500)でも .sort が例外を投げて無限スピナーにならないよう空配列に。
-      const list: Equipment[] = Array.isArray(data) ? data : [];
-      const sortedData = [...list].sort((a, b) => a.name.localeCompare(b.name));
-      setEquipments(sortedData);
-    } catch (error) {
-      console.error("Error fetching equipments:", error);
-    } finally {
-      // fetch/json が例外でも必ずスピナーを解除する
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    refetch();
-  }, []);
-
+  const { data, isLoading, refetch } = useCachedEndpoint<Equipment>("/api/lists");
+  // 共有キャッシュの配列を破壊しないよう、非破壊でソートする
+  const equipments = useMemo(
+    () => [...data].sort((a, b) => a.name.localeCompare(b.name)),
+    [data]
+  );
   return { equipments, isLoading, refetch };
 };

--- a/app/(protected)/ems/_hooks/use-tag-creation.test.ts
+++ b/app/(protected)/ems/_hooks/use-tag-creation.test.ts
@@ -1,22 +1,19 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("axios", () => ({
-  default: { post: vi.fn() },
-}));
-
-import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useTagCreation } from "./use-tag-creation";
 
 const refetchTags = vi.fn(async () => {});
 const alertMock = vi.fn();
+const fetchMock = vi.fn();
 
 beforeEach(() => {
-  vi.mocked(axios.post).mockReset();
+  fetchMock.mockReset();
   refetchTags.mockClear();
   alertMock.mockReset();
   vi.stubGlobal("alert", alertMock);
+  vi.stubGlobal("fetch", fetchMock);
 });
 
 afterEach(() => {
@@ -40,7 +37,7 @@ describe("useTagCreation", () => {
     });
 
     expect(alertMock).toHaveBeenCalledWith("カテゴリ名は1文字以上入力してください.");
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(result.current.addTagName).toBe("");
   });
 
@@ -56,12 +53,12 @@ describe("useTagCreation", () => {
     });
 
     expect(alertMock).toHaveBeenCalledWith("このカテゴリは既に存在しています.");
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(result.current.addTagName).toBe("");
   });
 
   it("posts new tag and refetches on success, clearing name + color", async () => {
-    vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
+    fetchMock.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() => useTagCreation(defaultParams));
 
@@ -74,21 +71,24 @@ describe("useTagCreation", () => {
       await result.current.submit();
     });
 
-    expect(axios.post).toHaveBeenCalledWith(
-      "/api/tags",
-      {
-        name: "Lights",
-        color: "#0000ff",
-      },
-      { headers: managerAuthHeaders() },
-    );
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tags");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      ...managerAuthHeaders(),
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      name: "Lights",
+      color: "#0000ff",
+    });
     expect(refetchTags).toHaveBeenCalledOnce();
     expect(result.current.addTagName).toBe("");
     expect(result.current.editTagColor).toBe("");
   });
 
   it("alerts and keeps input when the POST fails (e.g. 403/500)", async () => {
-    vi.mocked(axios.post).mockRejectedValue(new Error("forbidden"));
+    fetchMock.mockResolvedValue({ ok: false, status: 403 });
 
     const { result } = renderHook(() => useTagCreation(defaultParams));
 

--- a/app/(protected)/ems/_hooks/use-tag-creation.ts
+++ b/app/(protected)/ems/_hooks/use-tag-creation.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useState } from "react";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 
@@ -36,14 +35,16 @@ export const useTagCreation = ({ existingTags, refetchTags }: UseTagCreationPara
     }
 
     try {
-      await axios.post(
-        "/api/tags",
-        {
+      const res = await fetch("/api/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
+        body: JSON.stringify({
           name: addTagName,
           color: editTagColor,
-        },
-        { headers: managerAuthHeaders() },
-      );
+        }),
+      });
+      // fetch は HTTP エラーで throw しないため、明示的に catch へ流す
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     } catch (error) {
       console.error("Error creating tag:", error);
       alert("カテゴリの作成に失敗しました.");

--- a/app/(protected)/ems/_hooks/use-tags-list.test.ts
+++ b/app/(protected)/ems/_hooks/use-tags-list.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 
 describe("useTagsList", () => {
   it("starts with empty tags and isLoading=true", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useTagsList());
     expect(result.current.tags).toEqual([]);
     expect(result.current.isLoading).toBe(true);
@@ -32,7 +32,7 @@ describe("useTagsList", () => {
       { id: 1, name: "A", color: "#1" },
       { id: 2, name: "B", color: "#2" },
     ];
-    fetchMock.mockResolvedValue({ json: async () => data });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => data });
 
     const { result } = renderHook(() => useTagsList());
 
@@ -48,7 +48,7 @@ describe("useTagsList", () => {
       { id: 1, name: "A", color: "#1" },
       { id: 2, name: "B", color: "#2" },
     ];
-    fetchMock.mockResolvedValue({ json: async () => data });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => data });
 
     const { result } = renderHook(() => useTagsList({ sortById: true }));
 
@@ -69,7 +69,7 @@ describe("useTagsList", () => {
   });
 
   it("refetch re-runs the fetch", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useTagsList());
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/app/(protected)/ems/_hooks/use-tags-list.test.ts
+++ b/app/(protected)/ems/_hooks/use-tags-list.test.ts
@@ -1,11 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useTagsList } from "./use-tags-list";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/_hooks/use-tags-list.ts
+++ b/app/(protected)/ems/_hooks/use-tags-list.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 import type { Tag as Tags } from "@/types/domain";
 
 export interface UseTagsListOptions {
@@ -8,27 +9,13 @@ export interface UseTagsListOptions {
   sortById?: boolean;
 }
 
+// カテゴリ一覧。/api/tags のキャッシュは use-categories / use-tags と共有される。
 export const useTagsList = (options: UseTagsListOptions = {}) => {
   const { sortById = false } = options;
-  const [tags, setTags] = useState<Tags[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  const refetch = async () => {
-    try {
-      const response = await fetch("/api/tags");
-      const data: Tags[] = await response.json();
-      const next = sortById ? [...data].sort((a, b) => a.id - b.id) : data;
-      setTags(next);
-    } catch (err) {
-      console.error("カテゴリ一覧の取得に失敗しました", err);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    refetch();
-  }, []);
-
+  const { data, isLoading, refetch } = useCachedEndpoint<Tags>("/api/tags");
+  const tags = useMemo(
+    () => (sortById ? [...data].sort((a, b) => a.id - b.id) : data),
+    [data, sortById]
+  );
   return { tags, isLoading, refetch };
 };

--- a/app/(protected)/ems/categories/hooks/use-tag-add.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-add.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useState } from "react";
 import { toast } from "sonner";
 import { managerAuthHeaders } from "@/lib/manager-auth";
@@ -36,11 +35,13 @@ export const useTagAdd = ({ existingTags, refetchTags }: UseTagAddParams) => {
 
     setIsSubmitting(true);
     try {
-      await axios.post(
-        "/api/tags",
-        { name: trimmed, color },
-        { headers: managerAuthHeaders() },
-      );
+      const res = await fetch("/api/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
+        body: JSON.stringify({ name: trimmed, color }),
+      });
+      // fetch は HTTP エラーで throw しないため、明示的に catch へ流す
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       toast.success("カテゴリを追加しました");
       setName("");
       setColor(CATEGORY_PALETTE[0]);

--- a/app/(protected)/ems/categories/hooks/use-tag-deletion.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-deletion.test.ts
@@ -1,10 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("axios", () => ({
-  default: { delete: vi.fn() },
-}));
-
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 vi.mock("sonner", () => ({
@@ -14,19 +10,20 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useTagDeletion } from "./use-tag-deletion";
 
 const refetchTags = vi.fn(async () => {});
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const fetchMock = vi.fn();
 
 beforeEach(() => {
-  vi.mocked(axios.delete).mockReset();
+  fetchMock.mockReset();
   refetchTags.mockClear();
   toastSuccess.mockReset();
   toastError.mockReset();
   consoleErrorSpy.mockClear();
+  vi.stubGlobal("fetch", fetchMock);
 });
 
 afterEach(() => {
@@ -35,13 +32,14 @@ afterEach(() => {
 
 describe("useTagDeletion", () => {
   it("DELETEs, refetches, toasts success, and returns true", async () => {
-    vi.mocked(axios.delete).mockResolvedValue({ status: 200 } as never);
+    fetchMock.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() => useTagDeletion({ refetchTags }));
 
     const ok = await result.current.deleteTag(5);
 
-    expect(axios.delete).toHaveBeenCalledWith("/api/tags/5", {
+    expect(fetchMock).toHaveBeenCalledWith("/api/tags/5", {
+      method: "DELETE",
       headers: managerAuthHeaders(),
     });
     expect(toastSuccess).toHaveBeenCalledWith("カテゴリを削除しました");
@@ -50,7 +48,7 @@ describe("useTagDeletion", () => {
   });
 
   it("toasts error, does not refetch, and returns false on failure", async () => {
-    vi.mocked(axios.delete).mockRejectedValue(new Error("server"));
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
 
     const { result } = renderHook(() => useTagDeletion({ refetchTags }));
 

--- a/app/(protected)/ems/categories/hooks/use-tag-deletion.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-deletion.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { toast } from "sonner";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 
@@ -12,7 +11,12 @@ export const useTagDeletion = ({ refetchTags }: UseTagDeletionParams) => {
   // 削除確認は UI 側（AlertDialog・機材数警告付き）で行うため、ここでは確認せず削除を実行する。
   const deleteTag = async (id: number): Promise<boolean> => {
     try {
-      await axios.delete(`/api/tags/${id}`, { headers: managerAuthHeaders() });
+      const res = await fetch(`/api/tags/${id}`, {
+        method: "DELETE",
+        headers: managerAuthHeaders(),
+      });
+      // fetch は HTTP エラーで throw しないため、明示的に catch へ流す
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       toast.success("カテゴリを削除しました");
       await refetchTags();
       return true;

--- a/app/(protected)/ems/categories/hooks/use-tag-editing.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-editing.test.ts
@@ -83,6 +83,53 @@ describe("useTagEditing - saveEdit", () => {
     expect(ok).toBe(false);
   });
 
+  it("toasts error when renaming to an existing category name (自分以外との重複)", async () => {
+    // 同名カテゴリを許すと機材フォームのチップが2つ点灯し、保存時に別カテゴリへ
+    // 黙って付け替わるため、追加側（use-tag-add）と同じ重複チェックを行う
+    const { result } = renderHook(() =>
+      useTagEditing({
+        refetchTags,
+        existingTags: [
+          { id: 5, name: "音響" },
+          { id: 6, name: "カメラ" },
+        ],
+      })
+    );
+
+    act(() => {
+      result.current.startEdit(5, "音響", "#ff0000");
+      result.current.setEditTagName("カメラ");
+    });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.saveEdit(5);
+    });
+
+    expect(toastError).toHaveBeenCalledWith("同じ名前のカテゴリがすでにあります");
+    expect(axios.put).not.toHaveBeenCalled();
+    expect(ok).toBe(false);
+  });
+
+  it("allows saving the same name for the tag itself (自分自身は重複扱いしない)", async () => {
+    vi.mocked(axios.put).mockResolvedValue({ status: 200 } as never);
+
+    const { result } = renderHook(() =>
+      useTagEditing({ refetchTags, existingTags: [{ id: 5, name: "音響" }] })
+    );
+
+    act(() => {
+      result.current.startEdit(5, "音響", "#ff0000");
+    });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.saveEdit(5);
+    });
+
+    expect(ok).toBe(true);
+  });
+
   it("PUTs the tag, refetches, and returns true on success", async () => {
     vi.mocked(axios.put).mockResolvedValue({ status: 200 } as never);
 

--- a/app/(protected)/ems/categories/hooks/use-tag-editing.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-editing.test.ts
@@ -1,10 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("axios", () => ({
-  default: { put: vi.fn() },
-}));
-
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 vi.mock("sonner", () => ({
@@ -14,19 +10,20 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useTagEditing } from "./use-tag-editing";
 
 const refetchTags = vi.fn(async () => {});
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const fetchMock = vi.fn();
 
 beforeEach(() => {
-  vi.mocked(axios.put).mockReset();
+  fetchMock.mockReset();
   refetchTags.mockClear();
   toastSuccess.mockReset();
   toastError.mockReset();
   consoleErrorSpy.mockClear();
+  vi.stubGlobal("fetch", fetchMock);
 });
 
 afterEach(() => {
@@ -79,7 +76,7 @@ describe("useTagEditing - saveEdit", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith("カテゴリ名を入力してください");
-    expect(axios.put).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ok).toBe(false);
   });
 
@@ -107,12 +104,12 @@ describe("useTagEditing - saveEdit", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith("同じ名前のカテゴリがすでにあります");
-    expect(axios.put).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(ok).toBe(false);
   });
 
   it("allows saving the same name for the tag itself (自分自身は重複扱いしない)", async () => {
-    vi.mocked(axios.put).mockResolvedValue({ status: 200 } as never);
+    fetchMock.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
       useTagEditing({ refetchTags, existingTags: [{ id: 5, name: "音響" }] })
@@ -131,7 +128,7 @@ describe("useTagEditing - saveEdit", () => {
   });
 
   it("PUTs the tag, refetches, and returns true on success", async () => {
-    vi.mocked(axios.put).mockResolvedValue({ status: 200 } as never);
+    fetchMock.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() => useTagEditing({ refetchTags }));
 
@@ -144,14 +141,17 @@ describe("useTagEditing - saveEdit", () => {
       ok = await result.current.saveEdit(5);
     });
 
-    expect(axios.put).toHaveBeenCalledWith(
-      "/api/tags/5",
-      {
-        name: "Audio",
-        color: "#ff0000",
-      },
-      { headers: managerAuthHeaders() },
-    );
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tags/5");
+    expect(init.method).toBe("PUT");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      ...managerAuthHeaders(),
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      name: "Audio",
+      color: "#ff0000",
+    });
     expect(toastSuccess).toHaveBeenCalledWith("カテゴリを更新しました");
     expect(refetchTags).toHaveBeenCalledOnce();
     expect(result.current.editTagId).toBeNull();
@@ -159,7 +159,7 @@ describe("useTagEditing - saveEdit", () => {
   });
 
   it("toasts error and returns false on PUT failure", async () => {
-    vi.mocked(axios.put).mockRejectedValue(new Error("server"));
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
 
     const { result } = renderHook(() => useTagEditing({ refetchTags }));
 

--- a/app/(protected)/ems/categories/hooks/use-tag-editing.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-editing.ts
@@ -7,9 +7,11 @@ import { managerAuthHeaders } from "@/lib/manager-auth";
 
 export interface UseTagEditingParams {
   refetchTags: () => Promise<void>;
+  /** 重複名チェック用の既存カテゴリ一覧（自分自身は除外して判定する） */
+  existingTags?: { id: number; name: string }[];
 }
 
-export const useTagEditing = ({ refetchTags }: UseTagEditingParams) => {
+export const useTagEditing = ({ refetchTags, existingTags = [] }: UseTagEditingParams) => {
   const [editTagId, setEditTagId] = useState<number | null>(null);
   const [editTagName, setEditTagName] = useState<string>("");
   const [editTagColor, setEditTagColor] = useState<string>("");
@@ -32,15 +34,22 @@ export const useTagEditing = ({ refetchTags }: UseTagEditingParams) => {
   };
 
   const saveEdit = async (id: number): Promise<boolean> => {
-    if (!editTagName.trim()) {
+    const trimmed = editTagName.trim();
+    if (!trimmed) {
       toast.error("カテゴリ名を入力してください");
+      return false;
+    }
+    // 同名カテゴリを許すと、機材フォームのチップ選択（名前一致判定）が2つ同時に
+    // 点灯し、保存時は並び順で先のカテゴリへ黙って付け替わる（追加側と同じチェック）
+    if (existingTags.some((t) => t.name === trimmed && t.id !== id)) {
+      toast.error("同じ名前のカテゴリがすでにあります");
       return false;
     }
     try {
       await axios.put(
         `/api/tags/${id}`,
         {
-          name: editTagName,
+          name: trimmed,
           color: editTagColor,
         },
         { headers: managerAuthHeaders() },

--- a/app/(protected)/ems/categories/hooks/use-tag-editing.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-editing.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { managerAuthHeaders } from "@/lib/manager-auth";
@@ -46,14 +45,16 @@ export const useTagEditing = ({ refetchTags, existingTags = [] }: UseTagEditingP
       return false;
     }
     try {
-      await axios.put(
-        `/api/tags/${id}`,
-        {
+      const res = await fetch(`/api/tags/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
+        body: JSON.stringify({
           name: trimmed,
           color: editTagColor,
-        },
-        { headers: managerAuthHeaders() },
-      );
+        }),
+      });
+      // fetch は HTTP エラーで throw しないため、明示的に catch へ流す
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       toast.success("カテゴリを更新しました");
       setEditTagId(null);
       await refetchTags();

--- a/app/(protected)/ems/categories/hooks/use-tag-reorder.test.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-reorder.test.ts
@@ -1,16 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("axios", () => ({
-  default: { patch: vi.fn() },
-}));
-
 const toastError = vi.fn();
 vi.mock("sonner", () => ({
   toast: { error: (...a: unknown[]) => toastError(...a) },
 }));
 
-import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useTagReorder } from "./use-tag-reorder";
 import type { Tag } from "@/types/domain";
@@ -23,12 +18,14 @@ const tags: Tag[] = [
 
 const refetchTags = vi.fn(async () => {});
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const fetchMock = vi.fn();
 
 beforeEach(() => {
-  vi.mocked(axios.patch).mockReset();
+  fetchMock.mockReset();
   refetchTags.mockClear();
   toastError.mockReset();
   consoleErrorSpy.mockClear();
+  vi.stubGlobal("fetch", fetchMock);
 });
 
 afterEach(() => {
@@ -42,7 +39,7 @@ describe("useTagReorder", () => {
   });
 
   it("moveDown swaps optimistically and PATCHes the new order", async () => {
-    vi.mocked(axios.patch).mockResolvedValue({ status: 200 } as never);
+    fetchMock.mockResolvedValue({ ok: true });
     const { result } = renderHook(() => useTagReorder({ tags, refetchTags }));
 
     await act(async () => {
@@ -50,11 +47,14 @@ describe("useTagReorder", () => {
     });
 
     expect(result.current.order.map((t) => t.id)).toEqual([2, 1, 3]);
-    expect(axios.patch).toHaveBeenCalledWith(
-      "/api/tags/reorder",
-      { orderedIds: [2, 1, 3] },
-      { headers: managerAuthHeaders() },
-    );
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/tags/reorder");
+    expect(init.method).toBe("PATCH");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      ...managerAuthHeaders(),
+    });
+    expect(JSON.parse(init.body)).toEqual({ orderedIds: [2, 1, 3] });
     expect(refetchTags).toHaveBeenCalled();
   });
 
@@ -66,11 +66,11 @@ describe("useTagReorder", () => {
     });
 
     expect(result.current.order.map((t) => t.id)).toEqual([1, 2, 3]);
-    expect(axios.patch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("rolls back via refetch and toasts on PATCH failure", async () => {
-    vi.mocked(axios.patch).mockRejectedValue(new Error("server"));
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
     const { result } = renderHook(() => useTagReorder({ tags, refetchTags }));
 
     await act(async () => {

--- a/app/(protected)/ems/categories/hooks/use-tag-reorder.ts
+++ b/app/(protected)/ems/categories/hooks/use-tag-reorder.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { managerAuthHeaders } from "@/lib/manager-auth";
@@ -24,11 +23,13 @@ export const useTagReorder = ({ tags, refetchTags }: UseTagReorderParams) => {
   const persist = async (next: Tag[]) => {
     setIsSaving(true);
     try {
-      await axios.patch(
-        "/api/tags/reorder",
-        { orderedIds: next.map((t) => t.id) },
-        { headers: managerAuthHeaders() },
-      );
+      const res = await fetch("/api/tags/reorder", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
+        body: JSON.stringify({ orderedIds: next.map((t) => t.id) }),
+      });
+      // fetch は HTTP エラーで throw しないため、明示的に catch へ流す
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       await refetchTags();
     } catch (err) {
       console.error("並び順の更新に失敗しました", err);

--- a/app/(protected)/ems/categories/page.tsx
+++ b/app/(protected)/ems/categories/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { categoryColor, categoryIconPath, tint } from "@/lib/category-colors";
+import { CATEGORY_PALETTE, categoryColor, categoryIconPath, tint } from "@/lib/category-colors";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,7 +25,7 @@ import { useTagAdd } from "./hooks/use-tag-add";
 export default function CategoriesPage() {
   const { tags, isLoading, refetch } = useTagsList();
   const { equipments } = useEquipments();
-  const editing = useTagEditing({ refetchTags: refetch });
+  const editing = useTagEditing({ refetchTags: refetch, existingTags: tags });
   const { deleteTag } = useTagDeletion({ refetchTags: refetch });
   const reorder = useTagReorder({ tags, refetchTags: refetch });
   const add = useTagAdd({ existingTags: tags, refetchTags: refetch });
@@ -88,7 +88,7 @@ export default function CategoriesPage() {
                     aria-label="上へ移動"
                     disabled={index === 0 || reorder.isSaving}
                     onClick={() => reorder.moveUp(index)}
-                    className="flex h-5 w-6 items-center justify-center text-ink-faint hover:text-brand disabled:opacity-25"
+                    className="flex h-7 w-9 items-center justify-center text-ink-faint hover:text-brand disabled:opacity-25"
                   >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
                       <path d="M6 15l6-6 6 6" />
@@ -99,7 +99,7 @@ export default function CategoriesPage() {
                     aria-label="下へ移動"
                     disabled={index === rows.length - 1 || reorder.isSaving}
                     onClick={() => reorder.moveDown(index)}
-                    className="flex h-5 w-6 items-center justify-center text-ink-faint hover:text-brand disabled:opacity-25"
+                    className="flex h-7 w-9 items-center justify-center text-ink-faint hover:text-brand disabled:opacity-25"
                   >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
                       <path d="M6 9l6 6 6-6" />
@@ -118,29 +118,52 @@ export default function CategoriesPage() {
                 </span>
 
                 {isEditing ? (
-                  <>
-                    <input
-                      ref={editing.inputRef}
-                      value={editing.editTagName}
-                      onChange={(e) => editing.setEditTagName(e.target.value)}
-                      className="h-9 min-w-0 flex-1 rounded-[10px] border-[1.5px] border-brand bg-white px-3 text-sm outline-none"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => editing.saveEdit(tag.id)}
-                      className="h-9 flex-none rounded-[10px] bg-brand px-3.5 text-[13px] font-bold text-white hover:bg-brand-dark"
-                    >
-                      保存
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="編集をやめる"
-                      onClick={editing.cancelEdit}
-                      className="flex h-9 w-9 flex-none items-center justify-center rounded-[10px] border-[1.5px] border-line bg-white text-lg leading-none text-ink-muted"
-                    >
-                      ×
-                    </button>
-                  </>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <input
+                        ref={editing.inputRef}
+                        value={editing.editTagName}
+                        onChange={(e) => editing.setEditTagName(e.target.value)}
+                        className="h-9 min-w-0 flex-1 rounded-[10px] border-[1.5px] border-brand bg-white px-3 text-sm outline-none"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => editing.saveEdit(tag.id)}
+                        className="h-9 flex-none rounded-[10px] bg-brand px-3.5 text-[13px] font-bold text-white hover:bg-brand-dark"
+                      >
+                        保存
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="編集をやめる"
+                        onClick={editing.cancelEdit}
+                        className="flex h-9 w-9 flex-none items-center justify-center rounded-[10px] border-[1.5px] border-line bg-white text-lg leading-none text-ink-muted"
+                      >
+                        ×
+                      </button>
+                    </div>
+                    {/* 色の変更。作成後に直す手段が「削除→再作成」しかなく、
+                        その過程で所属機材が未分類化してしまっていた */}
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {CATEGORY_PALETTE.map((col) => {
+                        const on = editing.editTagColor === col;
+                        return (
+                          <button
+                            key={col}
+                            type="button"
+                            aria-label={`色 ${col}`}
+                            onClick={() => editing.setEditTagColor(col)}
+                            className="h-[26px] w-[26px] rounded-full p-0 transition-[border-color]"
+                            style={{
+                              background: col,
+                              border: `3px solid ${on ? col : "transparent"}`,
+                              boxShadow: `inset 0 0 0 2px #fff${on ? ", 0 0 0 1.5px " + col : ""}`,
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
                 ) : (
                   <>
                     <div className="min-w-0 flex-1">

--- a/app/(protected)/ems/categories/page.tsx
+++ b/app/(protected)/ems/categories/page.tsx
@@ -143,9 +143,13 @@ export default function CategoriesPage() {
                       </button>
                     </div>
                     {/* 色の変更。作成後に直す手段が「削除→再作成」しかなく、
-                        その過程で所属機材が未分類化してしまっていた */}
+                        その過程で所属機材が未分類化してしまっていた。
+                        現在色がパレット外（旧既定色など）でも選択中表示と復元ができるよう、
+                        現在色を先頭のスウォッチとして含める */}
                     <div className="mt-2 flex flex-wrap gap-2">
-                      {CATEGORY_PALETTE.map((col) => {
+                      {[...new Set<string>([editing.editTagColor, ...CATEGORY_PALETTE])]
+                        .filter(Boolean)
+                        .map((col) => {
                         const on = editing.editTagColor === col;
                         return (
                           <button

--- a/app/(protected)/ems/categories/page.tsx
+++ b/app/(protected)/ems/categories/page.tsx
@@ -229,7 +229,7 @@ export default function CategoriesPage() {
             <AlertDialogTitle>「{pendingDelete?.name}」を削除</AlertDialogTitle>
             <AlertDialogDescription>
               {pendingCount > 0
-                ? `このカテゴリの機材 ${pendingCount}点は「未分類」になります。`
+                ? `このカテゴリの機材 ${pendingCount}点は「未分類」になり、予約画面では末尾の「未分類」グループに表示されます。各機材の編集画面でカテゴリを付け直せます。`
                 : "この操作は取り消せません。"}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -78,11 +78,13 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
   }, [members, memberFilter]);
 
   // 「色＝人」の前提を守るため、素のハッシュ色（少人数でも高確率で衝突する）ではなく
-  // 全予約の部員一覧に対して重複しない割り当てを使う。チップ・詳細カードも同じ割り当て。
+  // 重複しない割り当てを使う。表示中の月の部員（members）を優先して割り当てることで、
+  // 履歴上の部員が16人を超えても「いま見えている月」の中では一意性が守られる。
+  // チップ・詳細カードも同じ割り当てを共有する。
   const memberColorOf = useMemo(() => {
-    const map = memberColorMap(allEvents.map((e) => e.name));
+    const map = memberColorMap(allEvents.map((e) => e.name), members);
     return (name: string | null | undefined) => (name && map.get(name)) || "#667085";
-  }, [allEvents]);
+  }, [allEvents, members]);
 
   const barEvents = useMemo<CalendarBarEvent<CalendarEvent>[]>(
     () =>

--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -13,7 +13,7 @@ import {
   formatRange,
 } from "@/lib/calendar/date-grid";
 import { buildMonthWeeks, type CalendarBarEvent } from "@/lib/calendar/build-month-weeks";
-import { memberColor, memberInitial } from "@/lib/calendar/member-colors";
+import { memberColorMap, memberInitial } from "@/lib/calendar/member-colors";
 import { daysLeftLabel } from "@/lib/calendar/reservation-labels";
 import { MonthGrid } from "@/components/calendar/MonthGrid";
 import { EquipmentGantt, type GanttRow } from "@/components/calendar/EquipmentGantt";
@@ -77,6 +77,13 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
     if (memberFilter != null && !members.includes(memberFilter)) setMemberFilter(null);
   }, [members, memberFilter]);
 
+  // 「色＝人」の前提を守るため、素のハッシュ色（少人数でも高確率で衝突する）ではなく
+  // 全予約の部員一覧に対して重複しない割り当てを使う。チップ・詳細カードも同じ割り当て。
+  const memberColorOf = useMemo(() => {
+    const map = memberColorMap(allEvents.map((e) => e.name));
+    return (name: string | null | undefined) => (name && map.get(name)) || "#667085";
+  }, [allEvents]);
+
   const barEvents = useMemo<CalendarBarEvent<CalendarEvent>[]>(
     () =>
       allEvents.map((ev) => {
@@ -85,12 +92,12 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
           key: ev.id,
           startIdx,
           endIdx,
-          color: memberColor(ev.name),
+          color: memberColorOf(ev.name),
           label: ev.title,
           data: ev,
         };
       }),
-    [allEvents]
+    [allEvents, memberColorOf]
   );
 
   const weeks = useMemo(
@@ -100,20 +107,23 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         matrix,
         isDesktop
           ? { headH: 26, laneH: 26, minH: 104 }
-          : { headH: 20, laneH: 20, minH: 62 }
+          : // モバイルはレーン間隔を広げてバー(18px)のタップしやすさを確保する
+            { headH: 20, laneH: 22, minH: 64 }
       ),
     [barEvents, matrix, isDesktop]
   );
 
-  // ガント: 今日の3日前から14日窓
-  const ganttWindowStart = todayIdx - 3;
+  // ガント: 既定は「今日の3日前から14日窓」。1週間単位で前後に送れる
+  //（固定窓だと来週末より先の空きが確認できず、月表示への切替に気づかないと詰む）。
+  const [ganttWeekOffset, setGanttWeekOffset] = useState(0);
   const ganttDayCount = 14;
+  const ganttWindowStart = todayIdx - 3 + ganttWeekOffset * 7;
+  const ganttWindowEnd = ganttWindowStart + ganttDayCount - 1;
   const ganttRows = useMemo<GanttRow<CalendarEvent>[]>(() => {
-    const winEnd = ganttWindowStart + ganttDayCount - 1;
     const byEquip = new Map<string, GanttRow<CalendarEvent>>();
     allEvents.forEach((ev) => {
       const { startIdx, endIdx } = eventInterval(ev);
-      if (endIdx < ganttWindowStart || startIdx > winEnd) return;
+      if (endIdx < ganttWindowStart || startIdx > ganttWindowEnd) return;
       let row = byEquip.get(ev.title);
       if (!row) {
         row = {
@@ -128,14 +138,14 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         key: ev.id,
         startIdx,
         endIdx,
-        color: memberColor(ev.name),
+        color: memberColorOf(ev.name),
         initial: memberInitial(ev.name),
         label: `〜${formatRange(endIdx, endIdx)}`,
         data: ev,
       });
     });
     return [...byEquip.values()];
-  }, [allEvents, ganttWindowStart]);
+  }, [allEvents, ganttWindowStart, ganttWindowEnd, memberColorOf]);
 
   const selectedEvent = allEvents.find((e) => e.id === selectedKey) ?? null;
   const detail = selectedEvent
@@ -214,6 +224,47 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
             </button>
           ))}
         </div>
+        {view === "gantt" && (
+          <div className="ml-auto flex items-center gap-1">
+            {ganttWeekOffset !== 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedKey(null);
+                  setGanttWeekOffset(0);
+                }}
+                className="flex h-8 items-center rounded-lg px-2.5 text-xs font-bold text-brand hover:bg-line-soft"
+              >
+                今日
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedKey(null);
+                setGanttWeekOffset((o) => o - 1);
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-ink-muted hover:bg-line-soft"
+              aria-label="前の週"
+            >
+              ‹
+            </button>
+            <span className="min-w-[104px] text-center text-xs font-black">
+              {formatRange(ganttWindowStart, ganttWindowEnd)}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedKey(null);
+                setGanttWeekOffset((o) => o + 1);
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-ink-muted hover:bg-line-soft"
+              aria-label="次の週"
+            >
+              ›
+            </button>
+          </div>
+        )}
         {view === "month" && (
           <div className="ml-auto flex items-center gap-1">
             {!isCurrentMonth && (
@@ -255,6 +306,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
               members={members}
               value={memberFilter}
               onChange={setMemberFilter}
+              colorOf={memberColorOf}
               className="mb-3"
             />
             <MonthGrid<CalendarEvent>
@@ -269,7 +321,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
           </div>
           <div ref={detailRef} className="md:sticky md:top-24 md:self-start scroll-mt-20">
             {detail ? (
-              <EventDetailPopover detail={detail} />
+              <EventDetailPopover detail={detail} color={memberColorOf(detail.who)} />
             ) : (
               <div className="rounded-2xl border border-dashed border-line bg-white p-8 text-center text-[12.5px] text-ink-faint">
                 バーをタップすると
@@ -296,7 +348,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
           )}
           {detail && (
             <div ref={detailRef} className="mt-3 scroll-mt-20">
-              <EventDetailPopover detail={detail} />
+              <EventDetailPopover detail={detail} color={memberColorOf(detail.who)} />
             </div>
           )}
         </div>

--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import {
   useCalendarData,
@@ -30,7 +30,7 @@ function eventInterval(ev: CalendarEvent) {
 }
 
 export function CalendarBoard({ initialView = "month" }: { initialView?: View }) {
-  const { allEvents, isFetching } = useCalendarData();
+  const { allEvents, isFetching, isError, refetch } = useCalendarData();
   const todayIdx = todayJstDayIndex();
   // PC では行高を上げてカレンダーを画面の高さに合わせて大きく見せる
   const isDesktop = useIsDesktop();
@@ -38,6 +38,15 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
   const [view, setView] = useState<View>(initialView);
   const [memberFilter, setMemberFilter] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState<number | null>(null);
+
+  // モバイルでは詳細カードがグリッドの下に積まれるため、バーをタップしても
+  // 画面外で「反応がない」ように見える。選択時にカードまでスクロールする。
+  const detailRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (selectedKey != null && !isDesktop) {
+      detailRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [selectedKey, isDesktop]);
 
   // 今日を含む月を初期表示。前後移動できる。
   const todayDate = new Date();
@@ -151,12 +160,37 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
     setViewMonth0((m) => (m === 11 ? 0 : m + 1));
     if (viewMonth0 === 11) setViewYear((y) => y + 1);
   };
+  const isCurrentMonth =
+    viewYear === todayDate.getFullYear() && viewMonth0 === todayDate.getMonth();
+  const goToday = () => {
+    setSelectedKey(null);
+    setViewYear(todayDate.getFullYear());
+    setViewMonth0(todayDate.getMonth());
+  };
 
   if (isFetching) {
     return (
       <div className="space-y-3">
         <Skeleton className="h-9 w-44" />
         <Skeleton className="h-[360px] w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
+        <p className="text-sm font-bold text-ink">カレンダーを読み込めませんでした。</p>
+        <p className="mt-1 text-[12.5px] text-ink-faint">
+          通信環境を確認して、もう一度お試しください。
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-4 h-10 rounded-xl bg-brand px-5 text-sm font-bold text-white"
+        >
+          再試行
+        </button>
       </div>
     );
   }
@@ -182,6 +216,15 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         </div>
         {view === "month" && (
           <div className="ml-auto flex items-center gap-1">
+            {!isCurrentMonth && (
+              <button
+                type="button"
+                onClick={goToday}
+                className="flex h-8 items-center rounded-lg px-2.5 text-xs font-bold text-brand hover:bg-line-soft"
+              >
+                今日
+              </button>
+            )}
             <button
               type="button"
               onClick={goPrevMonth}
@@ -224,7 +267,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
               }
             />
           </div>
-          <div className="md:sticky md:top-24 md:self-start">
+          <div ref={detailRef} className="md:sticky md:top-24 md:self-start scroll-mt-20">
             {detail ? (
               <EventDetailPopover detail={detail} />
             ) : (
@@ -252,7 +295,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
             />
           )}
           {detail && (
-            <div className="mt-3">
+            <div ref={detailRef} className="mt-3 scroll-mt-20">
               <EventDetailPopover detail={detail} />
             </div>
           )}

--- a/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCalendarData } from "./use-calendar-data";
 import { clearClientCache } from "@/lib/client-cache";
@@ -144,6 +144,26 @@ describe("useCalendarData", () => {
 
     expect(result.current.isError).toBe(true);
     expect(result.current.allEvents).toEqual([]);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not flip to isError when a revalidation fails after data has loaded", async () => {
+    // 取得済みデータがあるのに再検証（タブ復帰・操作後）の失敗で全画面エラーへ
+    // 乗っ取られないための契約（isError は「初回ロード失敗」専用）
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    setupHappyPath();
+
+    const { result } = renderHook(() => useCalendarData());
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.allEvents).toHaveLength(1);
+
+    fetchMock.mockRejectedValue(new Error("network down"));
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.allEvents).toHaveLength(1);
     consoleErrorSpy.mockRestore();
   });
 

--- a/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
@@ -21,19 +21,19 @@ afterEach(() => {
 const setupHappyPath = () => {
   // /api/users（Prisma User の形: キーは id）
   fetchMock.mockResolvedValueOnce({
-    json: async () => [{ id: "u1", name: "Taro" }],
+    ok: true, json: async () => [{ id: "u1", name: "Taro" }],
   });
   // /api/lists
   fetchMock.mockResolvedValueOnce({
-    json: async () => [{ id: 1, name: "Camera", detail: "", image: "", usable: true, tag_id: 10 }],
+    ok: true, json: async () => [{ id: 1, name: "Camera", detail: "", image: "", usable: true, tag_id: 10 }],
   });
   // /api/tags
   fetchMock.mockResolvedValueOnce({
-    json: async () => [{ id: 10, name: "Audio", color: "#ff0000" }],
+    ok: true, json: async () => [{ id: 10, name: "Audio", color: "#ff0000" }],
   });
   // /api/reserves
   fetchMock.mockResolvedValueOnce({
-    json: async () => [
+    ok: true, json: async () => [
       {
         id: 100,
         user_id: "u1",
@@ -48,7 +48,7 @@ const setupHappyPath = () => {
 
 describe("useCalendarData", () => {
   it("starts with empty events and isFetching=true", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useCalendarData());
     expect(result.current.allEvents).toEqual([]);
     expect(result.current.isFetching).toBe(true);
@@ -98,13 +98,13 @@ describe("useCalendarData", () => {
   });
 
   it("falls back to default color when tag color is missing", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [{ id: "u1", name: "Taro" }] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [{ id: "u1", name: "Taro" }] });
     fetchMock.mockResolvedValueOnce({
-      json: async () => [{ id: 1, name: "Camera", detail: "", image: "", usable: true, tag_id: 999 }],
+      ok: true, json: async () => [{ id: 1, name: "Camera", detail: "", image: "", usable: true, tag_id: 999 }],
     });
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // no tags
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] }); // no tags
     fetchMock.mockResolvedValueOnce({
-      json: async () => [
+      ok: true, json: async () => [
         {
           id: 100,
           user_id: "u1",
@@ -123,10 +123,10 @@ describe("useCalendarData", () => {
   });
 
   it("handles empty reserves response", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [] });
-    fetchMock.mockResolvedValueOnce({ json: async () => [] });
-    fetchMock.mockResolvedValueOnce({ json: async () => [] });
-    fetchMock.mockResolvedValueOnce({ json: async () => [] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useCalendarData());
     await waitFor(() => expect(result.current.isFetching).toBe(false));
@@ -177,7 +177,7 @@ describe("useCalendarData", () => {
     const { result } = renderHook(() => useCalendarData());
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     await result.current.refetch();
 
     await waitFor(() => expect(result.current.isError).toBe(false));

--- a/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
@@ -130,4 +130,35 @@ describe("useCalendarData", () => {
 
     expect(result.current.allEvents).toEqual([]);
   });
+
+  it("stops the skeleton and reports isError when a fetch rejects", async () => {
+    // 以前は fetch 失敗で isFetching が下りず無限スケルトンになっていた（回帰防止）
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useCalendarData());
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.allEvents).toEqual([]);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("recovers after a successful refetch", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => useCalendarData());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    fetchMock.mockResolvedValue({ json: async () => [] });
+    await result.current.refetch();
+
+    await waitFor(() => expect(result.current.isError).toBe(false));
+    expect(result.current.isFetching).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
@@ -1,11 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCalendarData } from "./use-calendar-data";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/common/hooks/use-calendar-data.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 import { getTextColorForBackground } from "@/lib/calendar-event-rendering";
 
 export interface CalendarEvent {
@@ -46,47 +47,37 @@ interface Reserve {
   isRenting: number;
 }
 
+// 共有カレンダーのデータ。4エンドポイントは互いに独立なので並行取得され、
+// /api/lists・/api/tags・/api/users のキャッシュは他画面のフックと共有される
+// （タブを行き来しても再マウントで即表示→裏で再検証。use-cached-endpoint 参照）。
 export const useCalendarData = () => {
-  const [allEvents, setAllEvents] = useState<CalendarEvent[]>([]);
-  const [isFetching, setIsFetching] = useState<boolean>(true);
-  const [isError, setIsError] = useState<boolean>(false);
+  const users = useCachedEndpoint<User>("/api/users");
+  const lists = useCachedEndpoint<List>("/api/lists");
+  const tags = useCachedEndpoint<Tag>("/api/tags");
+  // カレンダーは過去の予約履歴も表示するため、期間フィルタは付けない
+  const reserves = useCachedEndpoint<Reserve>("/api/reserves");
 
-  const fetchReservesData = async () => {
-    setIsFetching(true);
-    setIsError(false);
-    try {
-    // 4つのAPIは互いに独立なので並列取得する（従来は直列awaitでウォーターフォールになっていた）。
-    // 各APIはログイン必須になり得るため、401/500 の非配列ボディでも .reduce/.map が
-    // クラッシュしないよう Array.isArray で空配列にフォールバックする（他フックと同じ防御水準）。
-    const [reservesListsData1, reservesListsData2, tags, reservesData] = await Promise.all([
-      fetch("/api/users").then((res) => res.json()).then((d) => (Array.isArray(d) ? d : []) as User[]),
-      fetch("/api/lists").then((res) => res.json()).then((d) => (Array.isArray(d) ? d : []) as List[]),
-      fetch("/api/tags").then((res) => res.json()).then((d) => (Array.isArray(d) ? d : []) as Tag[]),
-      fetch("/api/reserves").then((res) => res.json()).then((d) => (Array.isArray(d) ? d : []) as Reserve[]),
-    ]);
-
+  const allEvents = useMemo<CalendarEvent[]>(() => {
     // ユーザーIDをキーにして名前をマッピング
-    const idToNameMap1: { [key: string]: string } = reservesListsData1.reduce((map, item) => {
-      map[item.id] = item.name;
-      return map;
-    }, {} as { [key: string]: string });
+    const idToNameMap1: { [key: string]: string } = {};
+    users.data.forEach((u) => {
+      idToNameMap1[u.id] = u.name;
+    });
 
     // IDをキーにして機材名と色をマッピング
     const idToNameMap2: { [key: string]: string } = {};
-    const idToColorMap: { [key: string]: string } = {};
     const idTolistId: { [key: number]: number } = {};
-
-    reservesListsData2.forEach((item) => {
+    lists.data.forEach((item) => {
       idToNameMap2[item.id] = item.name;
       idTolistId[item.id] = item.tag_id;
     });
 
-    tags.forEach((tag) => {
+    const idToColorMap: { [key: string]: string } = {};
+    tags.data.forEach((tag) => {
       idToColorMap[tag.id] = tag.color;
     });
 
-    // 新しいイベントの一時配列を作成
-    const newEvents: CalendarEvent[] = reservesData.map((item) => {
+    return reserves.data.map((item) => {
       // end は「利用最終日（inclusive）」をそのまま保持する。
       // 旧実装は FullCalendar の排他的 end 用に +1 日していたが、自作カレンダー
       // エンジン（lib/calendar）は inclusive-end 前提のため補正しない。
@@ -109,21 +100,16 @@ export const useCalendarData = () => {
         textColor,
       };
     });
+  }, [users.data, lists.data, tags.data, reserves.data]);
 
-    setAllEvents(newEvents);
-    } catch (error) {
-      // 1本でも fetch が失敗すると以前は isFetching が下りず、無限スケルトンのまま
-      // 固まっていた。エラーとして返し、呼び出し側で再試行できるようにする。
-      console.error("Error fetching calendar data:", error);
-      setIsError(true);
-    } finally {
-      setIsFetching(false);
-    }
+  const sources = [users, lists, tags, reserves];
+  // 1本でも初回未完了ならスケルトン（キャッシュ表示中の裏再検証では false のまま）
+  const isFetching = sources.some((s) => s.isLoading);
+  // 全画面エラーは「初回ロードに失敗した」ときだけ。取得済み表示は維持する
+  const isError = sources.some((s) => s.isError) && !sources.every((s) => s.hasLoaded);
+  const refetch = async () => {
+    await Promise.all(sources.map((s) => s.refetch()));
   };
 
-  useEffect(() => {
-    fetchReservesData();
-  }, []);
-
-  return { allEvents, isFetching, isError, refetch: fetchReservesData };
+  return { allEvents, isFetching, isError, refetch };
 };

--- a/app/(protected)/ems/common/hooks/use-calendar-data.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.ts
@@ -49,8 +49,12 @@ interface Reserve {
 export const useCalendarData = () => {
   const [allEvents, setAllEvents] = useState<CalendarEvent[]>([]);
   const [isFetching, setIsFetching] = useState<boolean>(true);
+  const [isError, setIsError] = useState<boolean>(false);
 
   const fetchReservesData = async () => {
+    setIsFetching(true);
+    setIsError(false);
+    try {
     // 4つのAPIは互いに独立なので並列取得する（従来は直列awaitでウォーターフォールになっていた）。
     // 各APIはログイン必須になり得るため、401/500 の非配列ボディでも .reduce/.map が
     // クラッシュしないよう Array.isArray で空配列にフォールバックする（他フックと同じ防御水準）。
@@ -107,12 +111,19 @@ export const useCalendarData = () => {
     });
 
     setAllEvents(newEvents);
-    setIsFetching(false);
+    } catch (error) {
+      // 1本でも fetch が失敗すると以前は isFetching が下りず、無限スケルトンのまま
+      // 固まっていた。エラーとして返し、呼び出し側で再試行できるようにする。
+      console.error("Error fetching calendar data:", error);
+      setIsError(true);
+    } finally {
+      setIsFetching(false);
+    }
   };
 
   useEffect(() => {
     fetchReservesData();
   }, []);
 
-  return { allEvents, isFetching };
+  return { allEvents, isFetching, isError, refetch: fetchReservesData };
 };

--- a/app/(protected)/ems/common/loading.tsx
+++ b/app/(protected)/ems/common/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// /ems/common はサーバー側で auth() + DB（ユーザー設定）を待ってから HTML を返すため、
+// この loading 境界が無いと「カレンダー」タブを押しても応答が返るまで画面が変わらず、
+// 反応していないように見えて二度タップされる。ページと同じ骨格を即時表示する。
+export default function Loading() {
+  return (
+    <div>
+      <h1 className="mb-3 text-lg font-black text-ink">カレンダー</h1>
+      <div className="space-y-3">
+        <Skeleton className="h-9 w-44" />
+        <Skeleton className="h-[360px] w-full rounded-2xl" />
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.test.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.test.ts
@@ -52,4 +52,37 @@ describe("useEquipmentDetails", () => {
 
     await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
   });
+
+  it("exposes isLoading until the fetch settles (空フォームの先出し・入力上書きの防止)", async () => {
+    fetchMock.mockResolvedValue({ json: async () => ({ name: "Camera" }) });
+
+    const { result } = renderHook(() => useEquipmentDetails({ equipmentId: "1" }));
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("reports isError on an HTTP error body instead of silently emptying the form", async () => {
+    // 404/500 の {error} ボディをパースすると undefined が入り無言の空フォームになっていた
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({ error: "not found" }) });
+
+    const { result } = renderHook(() => useEquipmentDetails({ equipmentId: "1" }));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("recovers via refetch after a failure", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useEquipmentDetails({ equipmentId: "1" }));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    fetchMock.mockResolvedValue({ json: async () => ({ name: "Camera" }) });
+    await result.current.refetch();
+
+    await waitFor(() => expect(result.current.isError).toBe(false));
+    expect(result.current.equipmentName).toBe("Camera");
+  });
 });

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.test.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 
 describe("useEquipmentDetails", () => {
   it("starts with empty fields", () => {
-    fetchMock.mockResolvedValue({ json: async () => ({}) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
     const { result } = renderHook(() => useEquipmentDetails({ equipmentId: "1" }));
     expect(result.current.equipmentName).toBe("");
     expect(result.current.equipmentDetail).toBe("");
@@ -27,7 +27,7 @@ describe("useEquipmentDetails", () => {
 
   it("loads /api/lists/<id> on mount", async () => {
     fetchMock.mockResolvedValue({
-      json: async () => ({
+      ok: true, json: async () => ({
         name: "Camera",
         detail: "DSLR",
         image: "https://example/cam.png",
@@ -54,7 +54,7 @@ describe("useEquipmentDetails", () => {
   });
 
   it("exposes isLoading until the fetch settles (空フォームの先出し・入力上書きの防止)", async () => {
-    fetchMock.mockResolvedValue({ json: async () => ({ name: "Camera" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ name: "Camera" }) });
 
     const { result } = renderHook(() => useEquipmentDetails({ equipmentId: "1" }));
     expect(result.current.isLoading).toBe(true);
@@ -79,7 +79,7 @@ describe("useEquipmentDetails", () => {
     const { result } = renderHook(() => useEquipmentDetails({ equipmentId: "1" }));
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    fetchMock.mockResolvedValue({ json: async () => ({ name: "Camera" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ name: "Camera" }) });
     await result.current.refetch();
 
     await waitFor(() => expect(result.current.isError).toBe(false));

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.ts
@@ -18,23 +18,37 @@ export const useEquipmentDetails = ({ equipmentId }: UseEquipmentDetailsParams) 
   const [equipmentDetail, setEquipmentDetail] = useState<string>("");
   const [equipmentImg, setEquipmentImg] = useState<string>("");
   const [equipmentTag, setEquipmentTag] = useState<number | undefined>();
+  // ロード状態が無いと空フォームが先に出て、遅い回線では入力し始めた文字が
+  // フェッチ結果で上書きされる。取得完了までpage側でスケルトンを出すために持つ。
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
 
   const fetchEquipmentData = async () => {
+    setIsLoading(true);
+    setIsError(false);
     try {
-      const equipmentData: EquipmentResponse = await fetch(`/api/lists/${equipmentId}`).then(
-        (res) => res.json(),
-      );
-      setEquipmentName(equipmentData.name);
-      setEquipmentDetail(equipmentData.detail);
-      setEquipmentImg(equipmentData.image);
+      const res = await fetch(`/api/lists/${equipmentId}`);
+      if (res.ok === false) {
+        // 404/401/500 の {error} ボディをパースすると undefined が各フィールドに
+        // 入り「無言の空フォーム」になるため、エラーとして扱う
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const equipmentData: EquipmentResponse = await res.json();
+      setEquipmentName(equipmentData.name ?? "");
+      setEquipmentDetail(equipmentData.detail ?? "");
+      setEquipmentImg(equipmentData.image ?? "");
       setEquipmentTag(equipmentData.tag_id);
     } catch (err) {
       console.error("機材データの取得に失敗しました:", err);
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
     }
   };
 
   useEffect(() => {
     fetchEquipmentData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {
@@ -44,5 +58,8 @@ export const useEquipmentDetails = ({ equipmentId }: UseEquipmentDetailsParams) 
     setEquipmentDetail,
     equipmentImg,
     equipmentTag,
+    isLoading,
+    isError,
+    refetch: fetchEquipmentData,
   };
 };

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-details.ts
@@ -28,7 +28,7 @@ export const useEquipmentDetails = ({ equipmentId }: UseEquipmentDetailsParams) 
     setIsError(false);
     try {
       const res = await fetch(`/api/lists/${equipmentId}`);
-      if (res.ok === false) {
+      if (!res.ok) {
         // 404/401/500 の {error} ボディをパースすると undefined が各フィールドに
         // 入り「無言の空フォーム」になるため、エラーとして扱う
         throw new Error(`HTTP ${res.status}`);

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.test.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.test.ts
@@ -120,6 +120,7 @@ describe("useEquipmentUpdate - submit", () => {
   it("uploads new file then PUTs with returned URL", async () => {
     const file = new File(["x"], "test.png", { type: "image/png" });
     fetchMock.mockResolvedValue({
+      ok: true,
       text: async () => JSON.stringify({ url: "https://blob/test.png" }),
     });
     vi.mocked(axios.put).mockResolvedValue({ data: {} } as never);
@@ -147,6 +148,33 @@ describe("useEquipmentUpdate - submit", () => {
       expect.any(Object),
     );
     expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("alerts and aborts when image upload responds with an error status", async () => {
+    // fetch は HTTP エラーで throw しないため、ok チェックが無いと {error} ボディをパースして
+    // image:undefined のまま PUT が成功し「古い画像のまま更新しました」になっていた（回帰防止）
+    const file = new File(["x"], "test.png", { type: "image/png" });
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => JSON.stringify({ error: "権限がありません。" }),
+    });
+
+    const { result } = renderHook(() => useEquipmentUpdate(defaultParams()));
+
+    act(() => {
+      result.current.onFileChange({
+        currentTarget: { files: [file] },
+      } as unknown as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(toastError).toHaveBeenCalledWith("画像のアップロードに失敗しました");
+    expect(axios.put).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it("alerts and aborts when image upload fails", async () => {

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.test.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.test.ts
@@ -1,13 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("axios", () => {
-  const isAxiosError = vi.fn(() => false);
-  return {
-    default: { put: vi.fn(), isAxiosError },
-  };
-});
-
 vi.mock("@/app/(protected)/ems/manager/useGetImageUrl", () => ({
   useGetImageUrl: () => ({ imageUrl: "data:image/png;base64,xxx" }),
 }));
@@ -21,7 +14,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useEquipmentUpdate } from "./use-equipment-update";
 
@@ -32,7 +24,6 @@ const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
-  vi.mocked(axios.put).mockReset();
   onSuccess.mockClear();
   toastSuccess.mockReset();
   toastError.mockReset();
@@ -94,7 +85,7 @@ describe("useEquipmentUpdate - file selection", () => {
 
 describe("useEquipmentUpdate - submit", () => {
   it("PUTs with current image URL when no new file selected", async () => {
-    vi.mocked(axios.put).mockResolvedValue({ data: {} } as never);
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
 
     const { result } = renderHook(() => useEquipmentUpdate(defaultParams()));
 
@@ -102,28 +93,33 @@ describe("useEquipmentUpdate - submit", () => {
       await result.current.submit();
     });
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(axios.put).toHaveBeenCalledWith(
-      "/api/lists/5",
-      {
-        name: "Camera",
-        detail: "DSLR",
-        image: "https://existing/img.png",
-        tag_id: 1,
-      },
-      { headers: { "Content-Type": "application/json", ...managerAuthHeaders() } },
-    );
+    // アップロード API へは行かず、/api/lists/5 への PUT 1回のみ
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/lists/5");
+    expect(init.method).toBe("PUT");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      ...managerAuthHeaders(),
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      name: "Camera",
+      detail: "DSLR",
+      image: "https://existing/img.png",
+      tag_id: 1,
+    });
     expect(toastSuccess).toHaveBeenCalledWith("機材情報を更新しました");
     expect(onSuccess).toHaveBeenCalled();
   });
 
   it("uploads new file then PUTs with returned URL", async () => {
     const file = new File(["x"], "test.png", { type: "image/png" });
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: async () => JSON.stringify({ url: "https://blob/test.png" }),
-    });
-    vi.mocked(axios.put).mockResolvedValue({ data: {} } as never);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ url: "https://blob/test.png" }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
     const { result } = renderHook(() => useEquipmentUpdate(defaultParams()));
 
@@ -137,15 +133,16 @@ describe("useEquipmentUpdate - submit", () => {
       await result.current.submit();
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/upload?filename=test.png", {
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/upload?filename=test.png", {
       method: "POST",
       body: file,
       headers: managerAuthHeaders(),
     });
-    expect(axios.put).toHaveBeenCalledWith(
-      "/api/lists/5",
-      expect.objectContaining({ image: "https://blob/test.png" }),
-      expect.any(Object),
+    const [putUrl, putInit] = fetchMock.mock.calls[1];
+    expect(putUrl).toBe("/api/lists/5");
+    expect(putInit.method).toBe("PUT");
+    expect(JSON.parse(putInit.body)).toEqual(
+      expect.objectContaining({ image: "https://blob/test.png" })
     );
     expect(onSuccess).toHaveBeenCalled();
   });
@@ -173,7 +170,9 @@ describe("useEquipmentUpdate - submit", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith("画像のアップロードに失敗しました");
-    expect(axios.put).not.toHaveBeenCalled();
+    // アップロードの1回のみで、/api/lists への PUT には到達しない
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/upload?filename=test.png");
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
@@ -194,12 +193,18 @@ describe("useEquipmentUpdate - submit", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith("画像のアップロードに失敗しました");
-    expect(axios.put).not.toHaveBeenCalled();
+    // fetch はアップロードで reject した1回のみで、/api/lists への PUT には到達しない
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/upload?filename=test.png");
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it("alerts on PUT failure", async () => {
-    vi.mocked(axios.put).mockRejectedValue(new Error("server"));
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({ error: "server" }),
+    });
 
     const { result } = renderHook(() => useEquipmentUpdate(defaultParams()));
 

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.ts
@@ -48,7 +48,12 @@ export const useEquipmentUpdate = ({
             headers: managerAuthHeaders(),
           });
           const responseText = await responseVercel.text();
-          console.log("Image upload response:", responseText);
+
+          // fetch は HTTP エラーでは throw せず、API のエラー応答 {error:...} も有効な JSON の
+          // ため、ok チェックなしでは catch に入らず「古い画像のまま更新しました」になっていた。
+          if (!responseVercel.ok) {
+            throw new Error(`画像アップロードに失敗: ${responseVercel.status} ${responseText}`);
+          }
 
           // アップロード API（R2）の応答は { url } のみ（旧 Vercel Blob の PutBlobResult 依存を除去）
           const blob = JSON.parse(responseText) as { url: string };

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { useGetImageUrl } from "@/app/(protected)/ems/manager/useGetImageUrl";
@@ -69,27 +68,28 @@ export const useEquipmentUpdate = ({
       }
 
       try {
-        const response = await axios.put(
-          `/api/lists/${equipmentId}`,
-          {
+        const response = await fetch(`/api/lists/${equipmentId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
+          body: JSON.stringify({
             name: equipmentName,
             detail: equipmentDetail,
             image: blobUrl,
             tag_id: tags.find((tag) => tag.name === selectedTagName)?.id,
-          },
-          {
-            headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
-          },
-        );
-        console.log("Update response:", response.data);
+          }),
+        });
+        // fetch は HTTP エラーで throw しない。旧 axios 実装が catch 側で出していた
+        // レスポンス本文（Response data）のログはエラーメッセージに含めて引き継ぐ。
+        if (!response.ok) {
+          const body = await response.text().catch(() => "");
+          throw new Error(`HTTP ${response.status}${body ? `: ${body}` : ""}`);
+        }
+        console.log("Update response:", await response.json().catch(() => undefined));
         toast.success("機材情報を更新しました");
         onSuccess();
         return true;
       } catch (error) {
         console.error("Failed to update equipment:", error);
-        if (axios.isAxiosError(error)) {
-          console.error("Response data:", error.response?.data);
-        }
         toast.error("機材情報の更新に失敗しました");
         return false;
       }

--- a/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.ts
+++ b/app/(protected)/ems/edit/[equipmentId]/hooks/use-equipment-update.ts
@@ -5,6 +5,7 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { useGetImageUrl } from "@/app/(protected)/ems/manager/useGetImageUrl";
 import { managerAuthHeaders } from "@/lib/manager-auth";
+import { compressImage } from "@/lib/image-compress";
 import type { Tag as Tags } from "@/types/domain";
 
 export interface UseEquipmentUpdateParams {
@@ -42,9 +43,11 @@ export const useEquipmentUpdate = ({
 
       if (imageFile) {
         try {
-          const responseVercel = await fetch(`/api/upload?filename=${imageFile.name}`, {
+          // 新規登録側と同じく、アップロード前にブラウザで縮小する（失敗時は原本のまま）
+          const uploadFile = await compressImage(imageFile);
+          const responseVercel = await fetch(`/api/upload?filename=${uploadFile.name}`, {
             method: "POST",
-            body: imageFile,
+            body: uploadFile,
             headers: managerAuthHeaders(),
           });
           const responseText = await responseVercel.text();

--- a/app/(protected)/ems/edit/[equipmentId]/page.tsx
+++ b/app/(protected)/ems/edit/[equipmentId]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { EquipmentForm } from "@/app/(protected)/ems/_components/EquipmentForm";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useEquipmentDetails } from "./hooks/use-equipment-details";
 import { useTagsList } from "../../_hooks/use-tags-list";
 import { useEquipmentUpdate } from "./hooks/use-equipment-update";
@@ -20,6 +21,9 @@ export default function EditPage() {
     setEquipmentDetail,
     equipmentImg,
     equipmentTag,
+    isLoading: detailsLoading,
+    isError: detailsError,
+    refetch: refetchDetails,
   } = useEquipmentDetails({ equipmentId });
 
   const { tags } = useTagsList();
@@ -69,6 +73,27 @@ export default function EditPage() {
         <h1 className="m-0 text-lg font-black text-ink">機材情報の編集</h1>
       </div>
 
+      {/* 取得完了前にフォームを出すと、入力し始めた文字がフェッチ結果で上書きされる */}
+      {detailsLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-[180px] w-full rounded-2xl" />
+          <Skeleton className="h-[260px] w-full rounded-2xl" />
+        </div>
+      ) : detailsError ? (
+        <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
+          <p className="text-sm font-bold text-ink">機材情報を読み込めませんでした。</p>
+          <p className="mt-1 text-[12.5px] text-ink-faint">
+            通信環境を確認して、もう一度お試しください。
+          </p>
+          <button
+            type="button"
+            onClick={() => refetchDetails()}
+            className="mt-4 h-10 rounded-xl bg-brand px-5 text-sm font-bold text-white"
+          >
+            再試行
+          </button>
+        </div>
+      ) : (
       <EquipmentForm
         categories={tags.map((t) => ({ id: t.id, name: t.name, color: t.color }))}
         name={equipmentName}
@@ -86,6 +111,7 @@ export default function EditPage() {
         canSubmit={canSubmit}
         isSubmitting={submitting}
       />
+      )}
     </div>
   );
 }

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.test.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.test.tsx
@@ -29,7 +29,7 @@ beforeEach(() => {
   // BookingWizard は useCachedEndpoint("/api/users") を実物のまま使うため、
   // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
   clearClientCache();
-  fetchMock.mockResolvedValue({ json: async () => [] }); // /api/users
+  fetchMock.mockResolvedValue({ ok: true, json: async () => [] }); // /api/users
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.test.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// BookingWizard の表示優先順位（全画面エラーの出し分け）を固定するテスト。
+// データ取得はすべてフックをモックして、UI の分岐だけを検証する。
+
+const { useReservesMock } = vi.hoisted(() => ({ useReservesMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/app/(protected)/ems/_hooks/use-equipments", () => ({
+  useEquipments: () => ({ equipments: [], isLoading: false }),
+}));
+vi.mock("@/app/(protected)/ems/equipment-list/hooks/use-categories", () => ({
+  useCategories: () => ({ categories: [], isLoading: false, refetch: vi.fn() }),
+}));
+vi.mock("@/app/(protected)/ems/equipment-list/hooks/use-reserves", () => ({
+  useReserves: () => useReservesMock(),
+}));
+vi.mock("@/app/(protected)/ems/equipment-list/hooks/use-create-reservations", () => ({
+  useCreateReservations: () => ({ isSubmitting: false, createReservations: vi.fn() }),
+}));
+
+import { BookingWizard } from "./BookingWizard";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockResolvedValue({ json: async () => [] }); // /api/users
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+  useReservesMock.mockReset();
+});
+
+describe("BookingWizard の全画面エラーの出し分け", () => {
+  it("初回ロードに失敗したときは全画面エラー＋再試行を出す", () => {
+    useReservesMock.mockReturnValue({
+      reserves: [],
+      isLoading: false,
+      isError: true,
+      hasLoaded: false,
+      refetch: vi.fn(),
+    });
+
+    render(<BookingWizard />);
+
+    expect(screen.getByText("空き状況を読み込めませんでした。")).toBeDefined();
+    expect(screen.getByRole("button", { name: "再試行" })).toBeDefined();
+  });
+
+  it("取得済みデータがあれば、バックグラウンド再取得の失敗でウィザードを乗っ取らない", () => {
+    // visibilitychange 再取得や予約成功直後の refetch が失敗しても、
+    // 進行中のウィザード（期間選択など）を全画面エラーで置き換えない
+    useReservesMock.mockReturnValue({
+      reserves: [],
+      isLoading: false,
+      isError: true,
+      hasLoaded: true,
+      refetch: vi.fn(),
+    });
+
+    render(<BookingWizard />);
+
+    expect(screen.queryByText("空き状況を読み込めませんでした。")).toBeNull();
+    // ウィザード本体（モバイルのステップ表記「期間」）が表示されている
+    expect(screen.getAllByText("期間").length).toBeGreaterThan(0);
+  });
+
+  it("読み込み中はスケルトンを出し、エラー画面は出さない", () => {
+    useReservesMock.mockReturnValue({
+      reserves: [],
+      isLoading: true,
+      isError: false,
+      hasLoaded: false,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<BookingWizard />);
+
+    expect(screen.queryByText("空き状況を読み込めませんでした。")).toBeNull();
+    expect(container.querySelectorAll("[class*='animate-pulse']").length).toBeGreaterThan(0);
+  });
+});

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.test.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.test.tsx
@@ -21,10 +21,14 @@ vi.mock("@/app/(protected)/ems/equipment-list/hooks/use-create-reservations", ()
 }));
 
 import { BookingWizard } from "./BookingWizard";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 
 beforeEach(() => {
+  // BookingWizard は useCachedEndpoint("/api/users") を実物のまま使うため、
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   fetchMock.mockResolvedValue({ json: async () => [] }); // /api/users
   vi.stubGlobal("fetch", fetchMock);
 });

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -37,11 +37,12 @@ interface UserLite {
 export function BookingWizard() {
   const router = useRouter();
   const { equipments, isLoading: eqLoading } = useEquipments();
-  const { categories } = useCategories();
+  const { categories, isLoading: catLoading } = useCategories();
   const {
     reserves,
     isLoading: reservesLoading,
     isError: reservesError,
+    hasLoaded: reservesLoaded,
     refetch: refetchReserves,
   } = useReserves();
   const { isSubmitting, createReservations } = useCreateReservations();
@@ -109,8 +110,9 @@ export function BookingWizard() {
 
     // カテゴリ未設定・カテゴリ削除後の機材も「未分類」として末尾に出す。
     // 以前はどのグループにも入らず、部員からは機材が消えて予約不可能になっていた。
-    // categories が空の間（読み込み中）は全機材が未分類に見えてしまうため出さない。
-    if (categories.length > 0) {
+    // 読み込み中は全機材が未分類に見えてしまうため isLoading で判定する
+    // （categories.length だと最後の1カテゴリを削除した後に未分類が出なくなる）。
+    if (!catLoading) {
       const knownIds = new Set(categories.map((c) => String(c.id)));
       const uncategorized = equipments.filter(
         (e) => e.tag_id == null || !knownIds.has(String(e.tag_id))
@@ -127,7 +129,7 @@ export function BookingWizard() {
     }
 
     return grouped.filter((g) => g.items.length > 0);
-  }, [categories, equipments, reserves, rangeOk, range, cart, users]);
+  }, [categories, catLoading, equipments, reserves, rangeOk, range, cart, users]);
 
   const cartItems = useMemo<CartItem[]>(
     () =>
@@ -176,17 +178,18 @@ export function BookingWizard() {
     if (res.createdCount > 0) {
       // 部分成功: 予約できた機材はカートから外し、できなかった機材を機材名で明示する。
       // 全体を失敗のように伝えると、成功分まで期間を変えて予約し直す二重予約につながる。
+      // トーストは1本に統合する（2本重ねるとモバイルでは背面の成功分が読めない）。
       setCart((prev) => prev.filter((id) => !res.createdIds.includes(id)));
-      toast.success(`${res.createdCount}件は予約が完了しました（マイ予約で確認できます）。`, {
-        duration: 8000,
-      });
       if (res.conflictIds.length > 0) {
         toast.error(
-          `${res.conflictIds.map(equipmentName).join("、")} は期間の重なる予約があり予約できませんでした。期間を変えて再度お試しください。`,
-          { duration: 8000 }
+          `${res.conflictIds.map(equipmentName).join("、")} は期間の重なる予約があり予約できませんでした。それ以外の${res.createdCount}件は予約済みです（マイ予約で確認できます）。期間を変えて再度お試しください。`,
+          { duration: 10000 }
         );
       } else {
-        toast.error(res.errorMessage ?? "一部の機材が予約できませんでした。");
+        toast.error(
+          `一部の機材が予約できませんでした（${res.createdCount}件は予約済み。マイ予約で確認できます）。${res.errorMessage ?? ""}`,
+          { duration: 10000 }
+        );
       }
     } else if (res.conflict) {
       toast.error(
@@ -205,9 +208,24 @@ export function BookingWizard() {
     setStep(1);
   };
 
+  // 完了画面はデータ取得状態に依存しないので最優先で出す。
+  // これより後に置くと、成功直後のバックグラウンド refetch が失敗したときに
+  // 「予約できたのにエラー画面に置き換わる」事故になる。
+  if (done) {
+    return (
+      <div className="mx-auto max-w-md">
+        <DoneScreen
+          doneText={`${rangeText} に ${cartItems.length}件の機材を予約しました`}
+          onToMyPage={() => router.push("/ems/mypage")}
+          onRestart={restart}
+        />
+      </div>
+    );
+  }
+
   // reserves の読み込み完了前に一覧を出すと、予約済みの機材まで
-  // 「この期間は空いています」と表示されてしまうため、両方の完了を待つ。
-  if (eqLoading || reservesLoading) {
+  // 「この期間は空いています」と表示されてしまうため、各取得の完了を待つ。
+  if (eqLoading || reservesLoading || catLoading) {
     return (
       <div className="space-y-3">
         <Skeleton className="h-10 w-full rounded-xl" />
@@ -216,7 +234,10 @@ export function BookingWizard() {
     );
   }
 
-  if (reservesError) {
+  // 全画面エラーは「一度も空き状況を取得できていない」ときだけ。
+  // 取得済みデータがあるのに visibilitychange 再取得の失敗などで画面ごと
+  // 乗っ取ると、進行中のウィザードが消えてしまう。
+  if (reservesError && !reservesLoaded) {
     return (
       <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
         <p className="text-sm font-bold text-ink">空き状況を読み込めませんでした。</p>
@@ -230,18 +251,6 @@ export function BookingWizard() {
         >
           再試行
         </button>
-      </div>
-    );
-  }
-
-  if (done) {
-    return (
-      <div className="mx-auto max-w-md">
-        <DoneScreen
-          doneText={`${rangeText} に ${cartItems.length}件の機材を予約しました`}
-          onToMyPage={() => router.push("/ems/mypage")}
-          onRestart={restart}
-        />
       </div>
     );
   }

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 import { useEquipments } from "@/app/(protected)/ems/_hooks/use-equipments";
 import { useCategories } from "@/app/(protected)/ems/equipment-list/hooks/use-categories";
 import { useReserves } from "@/app/(protected)/ems/equipment-list/hooks/use-reserves";
@@ -47,13 +48,8 @@ export function BookingWizard() {
   } = useReserves();
   const { isSubmitting, createReservations } = useCreateReservations();
 
-  const [users, setUsers] = useState<UserLite[]>([]);
-  useEffect(() => {
-    fetch("/api/users")
-      .then((r) => r.json())
-      .then((d) => setUsers(Array.isArray(d) ? d : []))
-      .catch(() => setUsers([]));
-  }, []);
+  // 部員名の解決用。キャッシュはカレンダー画面の /api/users と共有される
+  const { data: users } = useCachedEndpoint<UserLite>("/api/users");
 
   const todayIdx = todayJstDayIndex();
   const now = new Date();

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -61,6 +61,9 @@ export function BookingWizard() {
   const [cart, setCart] = useState<number[]>([]);
   const [step, setStep] = useState<1 | 2 | 3>(1); // モバイルのステップ
   const [done, setDone] = useState(false);
+  // 機材が増えても目当てを探せるよう、名前検索と「空きのみ」絞り込みを持つ
+  const [query, setQuery] = useState("");
+  const [freeOnly, setFreeOnly] = useState(false);
 
   const rangeOk = range.startIdx != null && range.endIdx != null;
   const startStr = range.startIdx != null ? dayIndexToDateString(range.startIdx) : "";
@@ -76,13 +79,18 @@ export function BookingWizard() {
     if (!rangeOk) return [];
 
     const toItem = (e: Equipment) => {
-      const conflict = reserves.find(
-        (r) =>
-          r.list_id === e.id &&
-          range.startIdx! <= toJstDayIndex(r.end) &&
-          range.endIdx! >= toJstDayIndex(r.start)
-      );
-      const free = !conflict;
+      // 競合は全件拾って開始日順に出す。先頭1件だけだと「表示された予約を避けて
+      // 期間を選び直したのにまだ弾かれる」という手戻りが起きる（DB挿入順は日付順ですらない）。
+      const conflicts = reserves
+        .filter(
+          (r) =>
+            r.list_id === e.id &&
+            range.startIdx! <= toJstDayIndex(r.end) &&
+            range.endIdx! >= toJstDayIndex(r.start)
+        )
+        .sort((a, b) => toJstDayIndex(a.start) - toJstDayIndex(b.start));
+      const free = conflicts.length === 0;
+      const first = conflicts[0];
       return {
         id: e.id,
         name: e.name,
@@ -91,7 +99,7 @@ export function BookingWizard() {
         free,
         sub: free
           ? "この期間は空いています"
-          : `${formatRange(toJstDayIndex(conflict!.start), toJstDayIndex(conflict!.end))} ${userName(conflict!.user_id)}が予約`,
+          : `${formatRange(toJstDayIndex(first.start), toJstDayIndex(first.end))} ${userName(first.user_id)}が予約${conflicts.length > 1 ? ` ほか${conflicts.length - 1}件` : ""}`,
         selected: cart.includes(e.id),
       };
     };
@@ -126,6 +134,20 @@ export function BookingWizard() {
 
     return grouped.filter((g) => g.items.length > 0);
   }, [categories, catLoading, equipments, reserves, rangeOk, range, cart, users]);
+
+  // 検索・空きのみ絞り込み（絞り込みで空になったカテゴリは出さない）
+  const visibleGroups = useMemo<PickGroup[]>(() => {
+    const q = query.trim().toLowerCase();
+    if (!q && !freeOnly) return groups;
+    return groups
+      .map((g) => ({
+        ...g,
+        items: g.items.filter(
+          (it) => (!freeOnly || it.free) && (!q || it.name.toLowerCase().includes(q))
+        ),
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [groups, query, freeOnly]);
 
   const cartItems = useMemo<CartItem[]>(
     () =>
@@ -283,7 +305,54 @@ export function BookingWizard() {
     />
   );
   const pickPanel = (
-    <EquipmentPickPanel groups={groups} rangeOk={rangeOk} onToggle={toggle} />
+    <div className="flex flex-col gap-2.5">
+      {rangeOk && (
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <svg
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint"
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="機材名で検索"
+              aria-label="機材名で検索"
+              className="h-10 w-full rounded-xl border-[1.5px] border-line bg-white pl-9 pr-3 text-[13px] outline-none focus:border-brand"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => setFreeOnly((v) => !v)}
+            aria-pressed={freeOnly}
+            className={cn(
+              "h-10 flex-none rounded-xl border-[1.5px] px-3 text-[12px] font-bold transition-colors",
+              freeOnly
+                ? "border-brand bg-brand-faint text-brand"
+                : "border-line bg-white text-ink-muted"
+            )}
+          >
+            空きのみ
+          </button>
+        </div>
+      )}
+      {rangeOk && visibleGroups.length === 0 ? (
+        <p className="rounded-2xl bg-white px-4 py-8 text-center text-[12.5px] text-ink-faint shadow-sm">
+          条件に合う機材がありません
+        </p>
+      ) : (
+        <EquipmentPickPanel groups={visibleGroups} rangeOk={rangeOk} onToggle={toggle} />
+      )}
+    </div>
   );
   const confirmPanel = (
     <ConfirmPanel

--- a/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
+++ b/app/(protected)/ems/equipment-list/_components/BookingWizard.tsx
@@ -20,6 +20,7 @@ import {
 import { categoryColor, categoryIconPath } from "@/lib/category-colors";
 import { flattenNewlines } from "@/lib/text";
 import type { DayRange } from "@/components/calendar/RangeMiniCalendar";
+import type { Equipment } from "@/types/domain";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { PeriodPanel } from "./PeriodPanel";
@@ -37,7 +38,12 @@ export function BookingWizard() {
   const router = useRouter();
   const { equipments, isLoading: eqLoading } = useEquipments();
   const { categories } = useCategories();
-  const { reserves, refetch: refetchReserves } = useReserves();
+  const {
+    reserves,
+    isLoading: reservesLoading,
+    isError: reservesError,
+    refetch: refetchReserves,
+  } = useReserves();
   const { isSubmitting, createReservations } = useCreateReservations();
 
   const [users, setUsers] = useState<UserLite[]>([]);
@@ -66,44 +72,61 @@ export function BookingWizard() {
   const days = rangeOk ? range.endIdx! - range.startIdx! + 1 : 0;
 
   const userName = (id: string) => users.find((u) => u.id === id)?.name ?? "他の人";
+  const equipmentName = (id: number) => equipments.find((e) => e.id === id)?.name ?? `#${id}`;
 
   // カテゴリ順にグループ化し、期間中の空き状況を付与する
   const groups = useMemo<PickGroup[]>(() => {
     if (!rangeOk) return [];
-    return categories
-      .map((cat) => {
-        const color = categoryColor(cat.color);
-        const items = equipments
-          .filter((e) => String(e.tag_id) === String(cat.id))
-          .map((e) => {
-            const conflict = reserves.find(
-              (r) =>
-                r.list_id === e.id &&
-                range.startIdx! <= toJstDayIndex(r.end) &&
-                range.endIdx! >= toJstDayIndex(r.start)
-            );
-            const free = !conflict;
-            return {
-              id: e.id,
-              name: e.name,
-              detail: flattenNewlines(e.detail ?? ""),
-              image: e.image ?? "",
-              free,
-              sub: free
-                ? "この期間は空いています"
-                : `${formatRange(toJstDayIndex(conflict!.start), toJstDayIndex(conflict!.end))} ${userName(conflict!.user_id)}が予約`,
-              selected: cart.includes(e.id),
-            };
-          });
-        return {
-          catId: String(cat.id),
-          catName: cat.name,
-          color,
-          iconPath: categoryIconPath(cat.name),
-          items,
-        };
-      })
-      .filter((g) => g.items.length > 0);
+
+    const toItem = (e: Equipment) => {
+      const conflict = reserves.find(
+        (r) =>
+          r.list_id === e.id &&
+          range.startIdx! <= toJstDayIndex(r.end) &&
+          range.endIdx! >= toJstDayIndex(r.start)
+      );
+      const free = !conflict;
+      return {
+        id: e.id,
+        name: e.name,
+        detail: flattenNewlines(e.detail ?? ""),
+        image: e.image ?? "",
+        free,
+        sub: free
+          ? "この期間は空いています"
+          : `${formatRange(toJstDayIndex(conflict!.start), toJstDayIndex(conflict!.end))} ${userName(conflict!.user_id)}が予約`,
+        selected: cart.includes(e.id),
+      };
+    };
+
+    const grouped = categories.map((cat) => ({
+      catId: String(cat.id),
+      catName: cat.name,
+      color: categoryColor(cat.color),
+      iconPath: categoryIconPath(cat.name),
+      items: equipments.filter((e) => String(e.tag_id) === String(cat.id)).map(toItem),
+    }));
+
+    // カテゴリ未設定・カテゴリ削除後の機材も「未分類」として末尾に出す。
+    // 以前はどのグループにも入らず、部員からは機材が消えて予約不可能になっていた。
+    // categories が空の間（読み込み中）は全機材が未分類に見えてしまうため出さない。
+    if (categories.length > 0) {
+      const knownIds = new Set(categories.map((c) => String(c.id)));
+      const uncategorized = equipments.filter(
+        (e) => e.tag_id == null || !knownIds.has(String(e.tag_id))
+      );
+      if (uncategorized.length > 0) {
+        grouped.push({
+          catId: "uncategorized",
+          catName: "未分類",
+          color: categoryColor(null),
+          iconPath: categoryIconPath(null),
+          items: uncategorized.map(toItem),
+        });
+      }
+    }
+
+    return grouped.filter((g) => g.items.length > 0);
   }, [categories, equipments, reserves, rangeOk, range, cart, users]);
 
   const cartItems = useMemo<CartItem[]>(
@@ -142,13 +165,36 @@ export function BookingWizard() {
   const handleSubmit = async () => {
     if (cart.length === 0) return;
     const res = await createReservations(cart, startStr, endStr);
-    await refetchReserves();
     if (res.ok) {
+      // 完了画面は空き状況を使わないので refetch を待たずに先へ進める
+      // （待つ間に isSubmitting が解けて確定ボタンが再活性化し、二度押しできる窓があった）。
       setDone(true);
+      void refetchReserves();
+      return;
+    }
+    await refetchReserves();
+    if (res.createdCount > 0) {
+      // 部分成功: 予約できた機材はカートから外し、できなかった機材を機材名で明示する。
+      // 全体を失敗のように伝えると、成功分まで期間を変えて予約し直す二重予約につながる。
+      setCart((prev) => prev.filter((id) => !res.createdIds.includes(id)));
+      toast.success(`${res.createdCount}件は予約が完了しました（マイ予約で確認できます）。`, {
+        duration: 8000,
+      });
+      if (res.conflictIds.length > 0) {
+        toast.error(
+          `${res.conflictIds.map(equipmentName).join("、")} は期間の重なる予約があり予約できませんでした。期間を変えて再度お試しください。`,
+          { duration: 8000 }
+        );
+      } else {
+        toast.error(res.errorMessage ?? "一部の機材が予約できませんでした。");
+      }
     } else if (res.conflict) {
-      toast.error("選択した期間にすでに予約が入った機材があります。期間を変更してください。");
+      toast.error(
+        `${res.conflictIds.map(equipmentName).join("、")} は選択した期間にすでに予約が入っています。期間を変更してください。`
+      );
     } else {
-      toast.error("予約の作成中にエラーが発生しました。");
+      // API が返す具体的な理由（「予約開始日は今日以降にしてください。」等）をそのまま見せる
+      toast.error(res.errorMessage ?? "予約の作成中にエラーが発生しました。");
     }
   };
 
@@ -159,11 +205,31 @@ export function BookingWizard() {
     setStep(1);
   };
 
-  if (eqLoading) {
+  // reserves の読み込み完了前に一覧を出すと、予約済みの機材まで
+  // 「この期間は空いています」と表示されてしまうため、両方の完了を待つ。
+  if (eqLoading || reservesLoading) {
     return (
       <div className="space-y-3">
         <Skeleton className="h-10 w-full rounded-xl" />
         <Skeleton className="h-[420px] w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (reservesError) {
+    return (
+      <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
+        <p className="text-sm font-bold text-ink">空き状況を読み込めませんでした。</p>
+        <p className="mt-1 text-[12.5px] text-ink-faint">
+          通信環境を確認して、もう一度お試しください。
+        </p>
+        <button
+          type="button"
+          onClick={() => refetchReserves()}
+          className="mt-4 h-10 rounded-xl bg-brand px-5 text-sm font-bold text-white"
+        >
+          再試行
+        </button>
       </div>
     );
   }
@@ -188,8 +254,24 @@ export function BookingWizard() {
       range={range}
       onRangeChange={(r) => {
         setRange(r);
-        // 期間を変えたら選択済み機材の空き前提が崩れるのでカートを空に
-        setCart([]);
+        // 期間変更でカートを全消去すると「期間を変更してください」の案内に従った
+        // ユーザーが機材を全部選び直すことになるため、新しい期間で空きがない機材
+        // だけを外す（期間選択の途中 = endIdx 未確定の間は何もしない）。
+        if (r.startIdx == null || r.endIdx == null) return;
+        const dropped = cart.filter((id) =>
+          reserves.some(
+            (rv) =>
+              rv.list_id === id &&
+              r.startIdx! <= toJstDayIndex(rv.end) &&
+              r.endIdx! >= toJstDayIndex(rv.start)
+          )
+        );
+        if (dropped.length > 0) {
+          setCart((prev) => prev.filter((id) => !dropped.includes(id)));
+          toast(
+            `${dropped.map(equipmentName).join("、")} は新しい期間では空きがないため選択から外しました。`
+          );
+        }
       }}
       onPrevMonth={goPrevMonth}
       onNextMonth={goNextMonth}
@@ -234,7 +316,12 @@ export function BookingWizard() {
             <button
               type="button"
               disabled={!rangeOk}
-              onClick={() => setStep(2)}
+              onClick={() => {
+                // 空き一覧を最新の予約状況で出す（マウント時の1回きりだと、開きっぱなしの
+                // タブで他の部員の予約が反映されず、確定時に初めて409で弾かれる）。
+                void refetchReserves();
+                setStep(2);
+              }}
               className="h-12 w-full rounded-xl bg-brand text-sm font-bold text-white transition-opacity disabled:opacity-40"
             >
               空きを見る →

--- a/app/(protected)/ems/equipment-list/_components/ConfirmPanel.tsx
+++ b/app/(protected)/ems/equipment-list/_components/ConfirmPanel.tsx
@@ -54,13 +54,16 @@ export function ConfirmPanel({
                 </span>
               )}
               <span className="flex-1 truncate text-[13.5px] font-bold">{c.name}</span>
+              {/* 見た目は26pxの丸のまま、タップ領域だけ44px相当に広げる（行の高さは -my で相殺） */}
               <button
                 type="button"
                 onClick={() => onRemove(c.id)}
                 aria-label={`${c.name}を外す`}
-                className="flex h-[26px] w-[26px] flex-none items-center justify-center rounded-full bg-[#EAECF0] text-[13px] text-ink-muted"
+                className="-my-2 -mr-1.5 flex h-11 w-11 flex-none items-center justify-center"
               >
-                ×
+                <span className="flex h-[26px] w-[26px] items-center justify-center rounded-full bg-[#EAECF0] text-[13px] text-ink-muted">
+                  ×
+                </span>
               </button>
             </div>
           ))

--- a/app/(protected)/ems/equipment-list/_components/PeriodPanel.tsx
+++ b/app/(protected)/ems/equipment-list/_components/PeriodPanel.tsx
@@ -28,11 +28,12 @@ export function PeriodPanel({
     <div className="rounded-2xl bg-white p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between px-1">
         <span className="text-sm font-black">期間を選ぶ</span>
+        {/* 月送りはヘッダー行の高さを変えずに -my でタップ領域を40pxへ広げる */}
         <div className="flex items-center gap-1">
           <button
             type="button"
             onClick={onPrevMonth}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-ink-muted hover:bg-line-soft"
+            className="-my-1.5 flex h-10 w-10 items-center justify-center rounded-lg text-ink-muted hover:bg-line-soft"
             aria-label="前の月"
           >
             ‹
@@ -41,7 +42,7 @@ export function PeriodPanel({
           <button
             type="button"
             onClick={onNextMonth}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-ink-muted hover:bg-line-soft"
+            className="-my-1.5 flex h-10 w-10 items-center justify-center rounded-lg text-ink-muted hover:bg-line-soft"
             aria-label="次の月"
           >
             ›

--- a/app/(protected)/ems/equipment-list/hooks/use-categories.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-categories.test.ts
@@ -1,11 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCategories } from "./use-categories";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/equipment-list/hooks/use-categories.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-categories.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 
 describe("useCategories", () => {
   it("starts with empty categories and isLoading=true", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useCategories());
     expect(result.current.categories).toEqual([]);
     expect(result.current.isLoading).toBe(true);
@@ -28,7 +28,7 @@ describe("useCategories", () => {
 
   it("fetches /api/tags on mount and stores result", async () => {
     fetchMock.mockResolvedValue({
-      json: async () => [
+      ok: true, json: async () => [
         { id: "1", name: "Audio", color: "#ff0000" },
         { id: "2", name: "Video", color: "#00ff00" },
       ],
@@ -56,7 +56,7 @@ describe("useCategories", () => {
 
   it("falls back to empty categories on a non-array (401/500) body", async () => {
     // /api/tags が認証ゲートで {error} を返しても .map がクラッシュしないことを固定
-    fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ error: "認証されていません。" }) });
 
     const { result } = renderHook(() => useCategories());
 

--- a/app/(protected)/ems/equipment-list/hooks/use-categories.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-categories.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 
 // equipment-list ページでは category.id を Select の value（string 必須）に直接渡しているため、
 // ここでは string として扱う。`@/types/domain` の Tag (id: number) との整合は別タスクで対応予定。
@@ -10,27 +10,8 @@ export interface Category {
   color: string;
 }
 
+// /api/tags のキャッシュは use-tags-list / use-tags と共有される。
 export const useCategories = () => {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  const refetch = async () => {
-    setIsLoading(true);
-    try {
-      const response = await fetch("/api/tags");
-      const data = await response.json();
-      // 401/500 の非配列ボディでも render の .map がクラッシュしないよう空配列にフォールバック
-      setCategories(Array.isArray(data) ? data : []);
-    } catch (error) {
-      console.error("Error fetching categories: ", error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    refetch();
-  }, []);
-
+  const { data: categories, isLoading, refetch } = useCachedEndpoint<Category>("/api/tags");
   return { categories, isLoading, refetch };
 };

--- a/app/(protected)/ems/equipment-list/hooks/use-create-reservations.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-create-reservations.test.ts
@@ -29,7 +29,13 @@ describe("useCreateReservations", () => {
       start: "2026-07-10",
       end: "2026-07-12",
     });
-    expect(res).toEqual({ ok: true, conflict: false, createdCount: 3 });
+    expect(res).toEqual({
+      ok: true,
+      conflict: false,
+      createdCount: 3,
+      createdIds: [1, 2, 3],
+      conflictIds: [],
+    });
   });
 
   it("409 が混ざると conflict=true・ok=false", async () => {
@@ -43,7 +49,35 @@ describe("useCreateReservations", () => {
       res = await result.current.createReservations([1, 2], "2026-07-10", "2026-07-12");
     });
 
-    expect(res).toEqual({ ok: false, conflict: true, createdCount: 1 });
+    expect(res).toEqual({
+      ok: false,
+      conflict: true,
+      createdCount: 1,
+      createdIds: [1],
+      conflictIds: [2],
+    });
+  });
+
+  it("409以外の失敗は API のエラーメッセージを拾う", async () => {
+    mockedPost.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 400, data: { error: "予約開始日は今日以降にしてください。" } },
+    });
+    const { result } = renderHook(() => useCreateReservations());
+
+    let res: Awaited<ReturnType<typeof result.current.createReservations>> | undefined;
+    await act(async () => {
+      res = await result.current.createReservations([1], "2020-01-01", "2020-01-02");
+    });
+
+    expect(res).toEqual({
+      ok: false,
+      conflict: false,
+      createdCount: 0,
+      createdIds: [],
+      conflictIds: [],
+      errorMessage: "予約開始日は今日以降にしてください。",
+    });
   });
 
   it("user_id は body に含めない（API がセッションから導出）", async () => {

--- a/app/(protected)/ems/equipment-list/hooks/use-create-reservations.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-create-reservations.test.ts
@@ -1,21 +1,21 @@
 import { renderHook, act } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCreateReservations } from "./use-create-reservations";
 
-vi.mock("axios");
-const mockedPost = vi.mocked(axios.post);
-// axios.isAxiosError はモックで失われるため、簡易実体に差し替える
-(axios as unknown as { isAxiosError: (v: unknown) => boolean }).isAxiosError = (v) =>
-  !!v && typeof v === "object" && "isAxiosError" in (v as object);
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
 
 afterEach(() => {
-  vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("useCreateReservations", () => {
   it("全件成功で ok=true", async () => {
-    mockedPost.mockResolvedValue({ data: {} });
+    fetchMock.mockResolvedValue({ ok: true });
     const { result } = renderHook(() => useCreateReservations());
 
     let res: Awaited<ReturnType<typeof result.current.createReservations>> | undefined;
@@ -23,8 +23,12 @@ describe("useCreateReservations", () => {
       res = await result.current.createReservations([1, 2, 3], "2026-07-10", "2026-07-12");
     });
 
-    expect(mockedPost).toHaveBeenCalledTimes(3);
-    expect(mockedPost).toHaveBeenCalledWith("/api/reserves", {
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/reserves");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(init.body)).toEqual({
       list_id: 1,
       start: "2026-07-10",
       end: "2026-07-12",
@@ -39,9 +43,9 @@ describe("useCreateReservations", () => {
   });
 
   it("409 が混ざると conflict=true・ok=false", async () => {
-    mockedPost
-      .mockResolvedValueOnce({ data: {} })
-      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 409 } });
+    fetchMock
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, status: 409, json: async () => ({}) });
     const { result } = renderHook(() => useCreateReservations());
 
     let res: Awaited<ReturnType<typeof result.current.createReservations>> | undefined;
@@ -59,9 +63,10 @@ describe("useCreateReservations", () => {
   });
 
   it("409以外の失敗は API のエラーメッセージを拾う", async () => {
-    mockedPost.mockRejectedValue({
-      isAxiosError: true,
-      response: { status: 400, data: { error: "予約開始日は今日以降にしてください。" } },
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "予約開始日は今日以降にしてください。" }),
     });
     const { result } = renderHook(() => useCreateReservations());
 
@@ -80,17 +85,33 @@ describe("useCreateReservations", () => {
     });
   });
 
+  it("ネットワーク例外は errorMessage なしの失敗扱い", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    const { result } = renderHook(() => useCreateReservations());
+
+    let res: Awaited<ReturnType<typeof result.current.createReservations>> | undefined;
+    await act(async () => {
+      res = await result.current.createReservations([1], "2026-07-10", "2026-07-12");
+    });
+
+    expect(res).toEqual({
+      ok: false,
+      conflict: false,
+      createdCount: 0,
+      createdIds: [],
+      conflictIds: [],
+    });
+  });
+
   it("user_id は body に含めない（API がセッションから導出）", async () => {
-    mockedPost.mockResolvedValue({ data: {} });
+    fetchMock.mockResolvedValue({ ok: true });
     const { result } = renderHook(() => useCreateReservations());
 
     await act(async () => {
       await result.current.createReservations([5], "2026-07-10", "2026-07-10");
     });
 
-    expect(mockedPost).toHaveBeenCalledWith(
-      "/api/reserves",
-      expect.not.objectContaining({ user_id: expect.anything() })
-    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).not.toHaveProperty("user_id");
   });
 });

--- a/app/(protected)/ems/equipment-list/hooks/use-create-reservations.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-create-reservations.ts
@@ -7,11 +7,16 @@ export interface CreateResult {
   ok: boolean; // 全件成功したか
   conflict: boolean; // 409（期間重複）が起きたか
   createdCount: number;
+  createdIds: number[]; // 予約を作成できた機材ID（部分成功時のカート整理に使う）
+  conflictIds: number[]; // 期間重複で弾かれた機材ID（どれが競合したか案内に使う）
+  errorMessage?: string; // 409以外の失敗で API が返した具体的メッセージ
 }
 
 // 選択した複数機材を同一期間で予約作成する。旧 use-bulk-reservation の submit を
 // alert 依存・FormEvent 依存から切り離し、結果を戻り値で返す（呼び出し側が toast/画面遷移を制御）。
 // user_id は API 側でセッションから導出されるため body には送らない。
+// 機材ごとに個別 POST するため「一部だけ成功」があり得る。全体を失敗のように
+// 伝えると成功分まで予約し直されて二重予約になるため、機材IDごとの結果を返す。
 export const useCreateReservations = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -26,15 +31,32 @@ export const useCreateReservations = () => {
         listIds.map((list_id) => axios.post("/api/reserves", { list_id, start, end }))
       );
 
-      const createdCount = results.filter((r) => r.status === "fulfilled").length;
-      const conflict = results.some(
-        (r) =>
-          r.status === "rejected" &&
-          axios.isAxiosError(r.reason) &&
-          r.reason.response?.status === 409
-      );
+      const createdIds: number[] = [];
+      const conflictIds: number[] = [];
+      let errorMessage: string | undefined;
+      results.forEach((r, i) => {
+        if (r.status === "fulfilled") {
+          createdIds.push(listIds[i]);
+          return;
+        }
+        if (axios.isAxiosError(r.reason) && r.reason.response?.status === 409) {
+          conflictIds.push(listIds[i]);
+          return;
+        }
+        if (!errorMessage && axios.isAxiosError(r.reason)) {
+          const body = r.reason.response?.data as { error?: string } | undefined;
+          if (body?.error) errorMessage = body.error;
+        }
+      });
 
-      return { ok: createdCount === listIds.length, conflict, createdCount };
+      return {
+        ok: createdIds.length === listIds.length,
+        conflict: conflictIds.length > 0,
+        createdCount: createdIds.length,
+        createdIds,
+        conflictIds,
+        errorMessage,
+      };
     } finally {
       setIsSubmitting(false);
     }

--- a/app/(protected)/ems/equipment-list/hooks/use-create-reservations.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-create-reservations.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useState } from "react";
 
 export interface CreateResult {
@@ -11,6 +10,29 @@ export interface CreateResult {
   conflictIds: number[]; // 期間重複で弾かれた機材ID（どれが競合したか案内に使う）
   errorMessage?: string; // 409以外の失敗で API が返した具体的メッセージ
 }
+
+// 機材1件分の POST 結果。fetch は HTTP エラーで throw しないため、
+// レスポンスをここで「作成成功 / 期間重複 / その他エラー」に分類して返す。
+type PostOutcome =
+  | { kind: "created" }
+  | { kind: "conflict" }
+  | { kind: "error"; message?: string };
+
+const postReservation = async (
+  list_id: number,
+  start: string,
+  end: string
+): Promise<PostOutcome> => {
+  const res = await fetch("/api/reserves", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ list_id, start, end }),
+  });
+  if (res.ok) return { kind: "created" };
+  if (res.status === 409) return { kind: "conflict" };
+  const body = (await res.json().catch(() => undefined)) as { error?: string } | undefined;
+  return { kind: "error", message: body?.error };
+};
 
 // 選択した複数機材を同一期間で予約作成する。旧 use-bulk-reservation の submit を
 // alert 依存・FormEvent 依存から切り離し、結果を戻り値で返す（呼び出し側が toast/画面遷移を制御）。
@@ -27,26 +49,26 @@ export const useCreateReservations = () => {
   ): Promise<CreateResult> => {
     setIsSubmitting(true);
     try {
+      // rejected はネットワーク例外のみ（HTTP エラーは postReservation が分類済み）。
+      // 従来どおり errorMessage なしの失敗として扱う。
       const results = await Promise.allSettled(
-        listIds.map((list_id) => axios.post("/api/reserves", { list_id, start, end }))
+        listIds.map((list_id) => postReservation(list_id, start, end))
       );
 
       const createdIds: number[] = [];
       const conflictIds: number[] = [];
       let errorMessage: string | undefined;
       results.forEach((r, i) => {
-        if (r.status === "fulfilled") {
+        if (r.status !== "fulfilled") return;
+        if (r.value.kind === "created") {
           createdIds.push(listIds[i]);
           return;
         }
-        if (axios.isAxiosError(r.reason) && r.reason.response?.status === 409) {
+        if (r.value.kind === "conflict") {
           conflictIds.push(listIds[i]);
           return;
         }
-        if (!errorMessage && axios.isAxiosError(r.reason)) {
-          const body = r.reason.response?.data as { error?: string } | undefined;
-          if (body?.error) errorMessage = body.error;
-        }
+        if (!errorMessage && r.value.message) errorMessage = r.value.message;
       });
 
       return {

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 
 describe("useReserves", () => {
   it("starts with empty reserves", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useReserves());
     expect(result.current.reserves).toEqual([]);
   });
@@ -33,7 +33,7 @@ describe("useReserves", () => {
     const data = [
       { id: 1, user_id: "u1", start: "2026-01-01", end: "2026-01-02", list_id: 1 },
     ];
-    fetchMock.mockResolvedValue({ json: async () => data });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => data });
 
     const { result } = renderHook(() => useReserves());
 
@@ -57,7 +57,7 @@ describe("useReserves", () => {
   });
 
   it("exposes isLoading until the first fetch settles", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useReserves());
     expect(result.current.isLoading).toBe(true);
@@ -67,7 +67,7 @@ describe("useReserves", () => {
   });
 
   it("refetches when the tab becomes visible again", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     renderHook(() => useReserves());
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -79,7 +79,7 @@ describe("useReserves", () => {
 
   it("does not refetch when the tab is hidden", async () => {
     // 「visible のときだけ再取得する」契約の負分岐を固定する
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     renderHook(() => useReserves());
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -106,7 +106,7 @@ describe("useReserves", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.hasLoaded).toBe(false);
 
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     await act(async () => {
       await result.current.refetch();
     });
@@ -120,7 +120,7 @@ describe("useReserves", () => {
     // 成功後の visibilitychange 再取得が失敗しても、表示中のデータを
     // 全画面エラーで置き換えないための契約（isError は立つが hasLoaded は保持）
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    fetchMock.mockResolvedValueOnce({ json: async () => [] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useReserves());
     await waitFor(() => expect(result.current.hasLoaded).toBe(true));
@@ -136,7 +136,7 @@ describe("useReserves", () => {
   });
 
   it("refetch re-runs the fetch", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useReserves());
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -149,7 +149,7 @@ describe("useReserves", () => {
   it("falls back to empty reserves on a non-array (401/500) body", async () => {
     // /api/reserves が認証ゲートで {error} を返しても競合判定/描画がクラッシュしないことを固定。
     // ガードが外れると setReserves がオブジェクトを格納し toEqual([]) が落ちる。
-    fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ error: "認証されていません。" }) });
 
     const { result } = renderHook(() => useReserves());
     await act(async () => {

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
@@ -44,6 +44,30 @@ describe("useReserves", () => {
     await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
 
     expect(result.current.reserves).toEqual([]);
+    // エラーを isError で返す（黙って「全件空き」と誤表示しない）
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("exposes isLoading until the first fetch settles", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    const { result } = renderHook(() => useReserves());
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("refetches when the tab becomes visible again", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    renderHook(() => useReserves());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
   it("refetch re-runs the fetch", async () => {

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
@@ -1,11 +1,18 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useReserves } from "./use-reserves";
+import { clearClientCache } from "@/lib/client-cache";
+import { dayIndexToDateString, todayJstDayIndex } from "@/lib/calendar/date-grid";
+
+// 空き判定に過去の予約は不要なので、フックは「今日(JST)以降」で絞って取得する
+const RESERVES_URL = `/api/reserves?from=${dayIndexToDateString(todayJstDayIndex())}`;
 
 const fetchMock = vi.fn();
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 
@@ -22,7 +29,7 @@ describe("useReserves", () => {
     expect(result.current.reserves).toEqual([]);
   });
 
-  it("fetches /api/reserves on mount and stores result", async () => {
+  it("fetches today-onward reserves on mount and stores result", async () => {
     const data = [
       { id: 1, user_id: "u1", start: "2026-01-01", end: "2026-01-02", list_id: 1 },
     ];
@@ -32,7 +39,7 @@ describe("useReserves", () => {
 
     await waitFor(() => expect(result.current.reserves).toHaveLength(1));
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/reserves");
+    expect(fetchMock).toHaveBeenCalledWith(RESERVES_URL);
     expect(result.current.reserves).toEqual(data);
   });
 

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.test.ts
@@ -70,6 +70,64 @@ describe("useReserves", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
+  it("does not refetch when the tab is hidden", async () => {
+    // 「visible のときだけ再取得する」契約の負分岐を固定する
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    renderHook(() => useReserves());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    try {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await new Promise((r) => setTimeout(r, 20));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      Reflect.deleteProperty(document, "visibilityState");
+    }
+  });
+
+  it("keeps hasLoaded=false on initial failure, then recovers via refetch", async () => {
+    // hasLoaded は「全画面エラーは初回ロード失敗のときだけ」の判定に使われる
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error("down"));
+
+    const { result } = renderHook(() => useReserves());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.hasLoaded).toBe(false);
+
+    fetchMock.mockResolvedValue({ json: async () => [] });
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.hasLoaded).toBe(true);
+    expect(result.current.isError).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it("keeps hasLoaded=true when a background refetch fails after a success", async () => {
+    // 成功後の visibilitychange 再取得が失敗しても、表示中のデータを
+    // 全画面エラーで置き換えないための契約（isError は立つが hasLoaded は保持）
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockResolvedValueOnce({ json: async () => [] });
+
+    const { result } = renderHook(() => useReserves());
+    await waitFor(() => expect(result.current.hasLoaded).toBe(true));
+
+    fetchMock.mockRejectedValue(new Error("down"));
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.hasLoaded).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
   it("refetch re-runs the fetch", async () => {
     fetchMock.mockResolvedValue({ json: async () => [] });
 

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Reserve } from "@/types/domain";
 
 export const useReserves = () => {
@@ -9,14 +9,22 @@ export const useReserves = () => {
   // 誤表示されるため、呼び出し側がスケルトンを出せるようローディング状態を持つ。
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
+  // 一度でも取得に成功したか。呼び出し側はこれで「初回ロード失敗（全画面エラー）」と
+  // 「バックグラウンド再取得の失敗（表示中のデータを維持）」を区別する。
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const hasLoadedRef = useRef(false);
 
   const refetch = async () => {
+    // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
+    if (!hasLoadedRef.current) setIsLoading(true);
     try {
       const response = await fetch("/api/reserves");
       const data = await response.json();
       // 401/500 の非配列ボディでも競合判定/描画がクラッシュしないよう空配列にフォールバック
       setReserves(Array.isArray(data) ? data : []);
       setIsError(false);
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
     } catch (error) {
       // 失敗を握りつぶすと「全件空き」の誤表示が恒久化するため、エラーとして呼び出し側へ返す
       console.error("Error fetching reserves:", error);
@@ -35,7 +43,8 @@ export const useReserves = () => {
     };
     document.addEventListener("visibilitychange", onVisible);
     return () => document.removeEventListener("visibilitychange", onVisible);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { reserves, isLoading, isError, refetch };
+  return { reserves, isLoading, isError, hasLoaded, refetch };
 };

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
@@ -1,41 +1,27 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
+import { dayIndexToDateString, todayJstDayIndex } from "@/lib/calendar/date-grid";
 import type { Reserve } from "@/types/domain";
 
+// 予約ウィザード用の予約一覧。
+// 空き判定に過去の予約は不要なので「今日(JST)以降に掛かる予約」だけを取得する。
+// 予約データは返却済みも消えずに溜まり続けるため、全件取得だと年々遅くなる。
 export const useReserves = () => {
-  const [reserves, setReserves] = useState<Reserve[]>([]);
-  // 読み込み完了前に reserves=[] のまま空き判定すると「全件空いています」と
-  // 誤表示されるため、呼び出し側がスケルトンを出せるようローディング状態を持つ。
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-  // 一度でも取得に成功したか。呼び出し側はこれで「初回ロード失敗（全画面エラー）」と
-  // 「バックグラウンド再取得の失敗（表示中のデータを維持）」を区別する。
-  const [hasLoaded, setHasLoaded] = useState(false);
-  const hasLoadedRef = useRef(false);
-
-  const refetch = async () => {
-    // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
-    if (!hasLoadedRef.current) setIsLoading(true);
-    try {
-      const response = await fetch("/api/reserves");
-      const data = await response.json();
-      // 401/500 の非配列ボディでも競合判定/描画がクラッシュしないよう空配列にフォールバック
-      setReserves(Array.isArray(data) ? data : []);
-      setIsError(false);
-      hasLoadedRef.current = true;
-      setHasLoaded(true);
-    } catch (error) {
-      // 失敗を握りつぶすと「全件空き」の誤表示が恒久化するため、エラーとして呼び出し側へ返す
-      console.error("Error fetching reserves:", error);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const url = useMemo(
+    () => `/api/reserves?from=${dayIndexToDateString(todayJstDayIndex())}`,
+    []
+  );
+  const {
+    data: reserves,
+    isLoading,
+    isError,
+    hasLoaded,
+    refetch,
+  } = useCachedEndpoint<Reserve>(url);
 
   useEffect(() => {
-    refetch();
     // PWA・放置タブからの復帰時に、古い空き状況のまま予約へ進んで
     // 確定時に初めて409で弾かれるのを防ぐため、表示復帰で再取得する。
     const onVisible = () => {
@@ -43,8 +29,7 @@ export const useReserves = () => {
     };
     document.addEventListener("visibilitychange", onVisible);
     return () => document.removeEventListener("visibilitychange", onVisible);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [refetch]);
 
   return { reserves, isLoading, isError, hasLoaded, refetch };
 };

--- a/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
+++ b/app/(protected)/ems/equipment-list/hooks/use-reserves.ts
@@ -5,6 +5,10 @@ import type { Reserve } from "@/types/domain";
 
 export const useReserves = () => {
   const [reserves, setReserves] = useState<Reserve[]>([]);
+  // 読み込み完了前に reserves=[] のまま空き判定すると「全件空いています」と
+  // 誤表示されるため、呼び出し側がスケルトンを出せるようローディング状態を持つ。
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
 
   const refetch = async () => {
     try {
@@ -12,14 +16,26 @@ export const useReserves = () => {
       const data = await response.json();
       // 401/500 の非配列ボディでも競合判定/描画がクラッシュしないよう空配列にフォールバック
       setReserves(Array.isArray(data) ? data : []);
+      setIsError(false);
     } catch (error) {
+      // 失敗を握りつぶすと「全件空き」の誤表示が恒久化するため、エラーとして呼び出し側へ返す
       console.error("Error fetching reserves:", error);
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
     }
   };
 
   useEffect(() => {
     refetch();
+    // PWA・放置タブからの復帰時に、古い空き状況のまま予約へ進んで
+    // 確定時に初めて409で弾かれるのを防ぐため、表示復帰で再取得する。
+    const onVisible = () => {
+      if (document.visibilityState === "visible") refetch();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
   }, []);
 
-  return { reserves, refetch };
+  return { reserves, isLoading, isError, refetch };
 };

--- a/app/(protected)/ems/manager/_components/EquipmentListPanel.tsx
+++ b/app/(protected)/ems/manager/_components/EquipmentListPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { categoryColor, tint } from "@/lib/category-colors";
-import { dayIndexToDateString, todayJstDayIndex } from "@/lib/calendar/date-grid";
+import { toJstDayIndex, todayJstDayIndex } from "@/lib/calendar/date-grid";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,18 +37,40 @@ export function EquipmentListPanel({
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<string>("すべて");
   const [pendingDelete, setPendingDelete] = useState<Equipment | null>(null);
-  // 削除対象に今後の予約が何件あるか（null = 取得中）。警告なしで消すと
-  // 部員の予約が黙って取り消されるため、ダイアログで件数を見せる
-  const [pendingReserveCount, setPendingReserveCount] = useState<number | null>(null);
+  // 削除対象の予約状況（null = 取得中 / "error" = 取得失敗）。警告なしで消すと
+  // 部員の予約が黙って取り消されるため、確認ダイアログで見せる。
+  // onLoanCount はサーバー側の409ガード（貸出中は削除不可）と同じ isRenting 2/3 判定。
+  const [pendingReserves, setPendingReserves] = useState<
+    { onLoanCount: number; futureCount: number } | "error" | null
+  >(null);
+  // 開き直し時に前の機材の遅い応答が後着して別機材の件数を出さないよう、対象IDを照合する
+  const pendingDeleteIdRef = useRef<number | null>(null);
 
   const openDelete = (eq: Equipment) => {
     setPendingDelete(eq);
-    setPendingReserveCount(null);
-    const from = dayIndexToDateString(todayJstDayIndex());
-    fetch(`/api/reserves?list_id=${eq.id}&from=${from}`)
-      .then((r) => r.json())
-      .then((d) => setPendingReserveCount(Array.isArray(d) ? d.length : 0))
-      .catch(() => setPendingReserveCount(0));
+    setPendingReserves(null);
+    pendingDeleteIdRef.current = eq.id;
+    const todayIdx = todayJstDayIndex();
+    fetch(`/api/reserves?list_id=${eq.id}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const d = (await r.json()) as { isRenting: number; end: string }[];
+        if (!Array.isArray(d)) throw new Error("unexpected body");
+        if (pendingDeleteIdRef.current !== eq.id) return;
+        setPendingReserves({
+          onLoanCount: d.filter((x) => x.isRenting === 2 || x.isRenting === 3).length,
+          futureCount: d.filter((x) => toJstDayIndex(x.end) >= todayIdx).length,
+        });
+      })
+      .catch(() => {
+        // 失敗を件数0扱いにすると警告だけが欠落するため、fail-safe 側に倒す
+        if (pendingDeleteIdRef.current === eq.id) setPendingReserves("error");
+      });
+  };
+
+  const closeDelete = () => {
+    setPendingDelete(null);
+    pendingDeleteIdRef.current = null;
   };
 
   const catById = useMemo(() => {
@@ -160,23 +182,35 @@ export function EquipmentListPanel({
         )}
       </div>
 
-      <AlertDialog open={!!pendingDelete} onOpenChange={(o) => !o && setPendingDelete(null)}>
+      <AlertDialog open={!!pendingDelete} onOpenChange={(o) => !o && closeDelete()}>
         <AlertDialogContent className="rounded-2xl">
           <AlertDialogHeader>
             <AlertDialogTitle>「{pendingDelete?.name}」を削除</AlertDialogTitle>
             <AlertDialogDescription>
-              {pendingReserveCount != null && pendingReserveCount > 0
-                ? `この機材には今後の予約が ${pendingReserveCount}件 あり、削除すると予約も取り消されます。この操作は取り消せません。`
-                : "この操作は取り消せません。"}
+              {pendingReserves === null
+                ? "予約状況を確認しています…"
+                : pendingReserves === "error"
+                  ? "予約状況を確認できませんでした。この機材に予約が残っている場合、削除すると予約も取り消されます。この操作は取り消せません。"
+                  : pendingReserves.onLoanCount > 0
+                    ? "この機材は現在貸出中のため削除できません。返却された後に削除してください。"
+                    : pendingReserves.futureCount > 0
+                      ? `この機材には今後の予約が ${pendingReserves.futureCount}件 あり、削除すると予約も取り消されます（予約した部員へは取り消しの通知が送られます）。この操作は取り消せません。`
+                      : "この操作は取り消せません。"}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>キャンセル</AlertDialogCancel>
             <AlertDialogAction
               className="bg-danger hover:bg-danger/90"
+              // 取得中は誤って警告なしで確定できないよう待たせる。貸出中はサーバーでも
+              // 409 で弾かれる（isRenting 2/3 の同一判定）ため、ここで先に案内して無効化
+              disabled={
+                pendingReserves === null ||
+                (pendingReserves !== "error" && pendingReserves.onLoanCount > 0)
+              }
               onClick={async () => {
                 if (pendingDelete) await onDelete(pendingDelete.id);
-                setPendingDelete(null);
+                closeDelete();
               }}
             >
               削除する

--- a/app/(protected)/ems/manager/_components/EquipmentListPanel.tsx
+++ b/app/(protected)/ems/manager/_components/EquipmentListPanel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { categoryColor, tint } from "@/lib/category-colors";
+import { dayIndexToDateString, todayJstDayIndex } from "@/lib/calendar/date-grid";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,16 +24,32 @@ export function EquipmentListPanel({
   onEdit,
   onDelete,
   gridCols = 1,
+  editingId = null,
 }: {
   equipments: Equipment[];
   categories: CategoryOption[];
   onEdit: (id: number) => void;
   onDelete: (id: number) => Promise<boolean>;
   gridCols?: 1 | 2;
+  /** 編集ページへ遷移中の機材ID（該当ボタンにスピナーを出す） */
+  editingId?: number | null;
 }) {
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<string>("すべて");
   const [pendingDelete, setPendingDelete] = useState<Equipment | null>(null);
+  // 削除対象に今後の予約が何件あるか（null = 取得中）。警告なしで消すと
+  // 部員の予約が黙って取り消されるため、ダイアログで件数を見せる
+  const [pendingReserveCount, setPendingReserveCount] = useState<number | null>(null);
+
+  const openDelete = (eq: Equipment) => {
+    setPendingDelete(eq);
+    setPendingReserveCount(null);
+    const from = dayIndexToDateString(todayJstDayIndex());
+    fetch(`/api/reserves?list_id=${eq.id}&from=${from}`)
+      .then((r) => r.json())
+      .then((d) => setPendingReserveCount(Array.isArray(d) ? d.length : 0))
+      .catch(() => setPendingReserveCount(0));
+  };
 
   const catById = useMemo(() => {
     const m = new Map<string, CategoryOption>();
@@ -111,17 +128,23 @@ export function EquipmentListPanel({
               <button
                 type="button"
                 onClick={() => onEdit(eq.id)}
+                disabled={editingId != null}
                 aria-label={`${eq.name}を編集`}
-                className="flex h-9 w-9 flex-none items-center justify-center rounded-[10px] border-[1.5px] border-line bg-white hover:border-brand"
+                className="flex h-9 w-9 flex-none items-center justify-center rounded-[10px] border-[1.5px] border-line bg-white hover:border-brand disabled:opacity-60"
               >
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#475467" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M12 20h9" />
-                  <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
-                </svg>
+                {editingId === eq.id ? (
+                  // 遷移中の表示。無反応に見えて連打されるのを防ぐ
+                  <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-line border-t-brand" />
+                ) : (
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#475467" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M12 20h9" />
+                    <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+                  </svg>
+                )}
               </button>
               <button
                 type="button"
-                onClick={() => setPendingDelete(eq)}
+                onClick={() => openDelete(eq)}
                 aria-label={`${eq.name}を削除`}
                 className="flex h-9 w-9 flex-none items-center justify-center rounded-[10px] border-[1.5px] border-[#FEE4E2] bg-[#FFF5F4] hover:bg-[#FEE4E2]"
               >
@@ -141,7 +164,11 @@ export function EquipmentListPanel({
         <AlertDialogContent className="rounded-2xl">
           <AlertDialogHeader>
             <AlertDialogTitle>「{pendingDelete?.name}」を削除</AlertDialogTitle>
-            <AlertDialogDescription>この操作は取り消せません。</AlertDialogDescription>
+            <AlertDialogDescription>
+              {pendingReserveCount != null && pendingReserveCount > 0
+                ? `この機材には今後の予約が ${pendingReserveCount}件 あり、削除すると予約も取り消されます。この操作は取り消せません。`
+                : "この操作は取り消せません。"}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>キャンセル</AlertDialogCancel>

--- a/app/(protected)/ems/manager/hooks/use-equipment-actions.test.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-actions.test.ts
@@ -82,7 +82,7 @@ describe("useEquipmentActions - delete", () => {
   });
 
   it("toasts error and does not refetch on failure", async () => {
-    fetchMock.mockResolvedValue({ ok: false });
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
 
     const { result } = renderHook(() => useEquipmentActions({ refetchEquipments }));
 
@@ -94,5 +94,22 @@ describe("useEquipmentActions - delete", () => {
     expect(refetchEquipments).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledWith("機材の削除に失敗しました");
     expect(ok).toBe(false);
+  });
+
+  it("surfaces the API error message (e.g. on-loan block) on failure", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "貸出中の機材は削除できません。返却された後に削除してください。" }),
+    });
+
+    const { result } = renderHook(() => useEquipmentActions({ refetchEquipments }));
+
+    await act(async () => {
+      await result.current.deleteEquipment(7);
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      "貸出中の機材は削除できません。返却された後に削除してください。"
+    );
   });
 });

--- a/app/(protected)/ems/manager/hooks/use-equipment-actions.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-actions.ts
@@ -28,7 +28,9 @@ export const useEquipmentActions = ({ refetchEquipments }: UseEquipmentActionsPa
       headers: managerAuthHeaders(),
     });
     if (!res.ok) {
-      toast.error("機材の削除に失敗しました");
+      // 「貸出中の機材は削除できません」等、API の具体的な理由をそのまま見せる
+      const body = (await res.json().catch(() => null)) as { error?: string } | null;
+      toast.error(body?.error ?? "機材の削除に失敗しました");
       return false;
     }
     await refetchEquipments();

--- a/app/(protected)/ems/manager/hooks/use-equipment-registration.test.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-registration.test.ts
@@ -55,11 +55,13 @@ afterEach(() => {
 });
 
 describe("useEquipmentRegistration - state", () => {
-  it("starts with empty form and selectedTag='all'", () => {
+  it("starts with empty form and no selected tag", () => {
     const { result } = renderHook(() => useEquipmentRegistration(defaultParams));
     expect(result.current.equipmentName).toBe("");
     expect(result.current.equipmentDetail).toBe("");
-    expect(result.current.selectedTag).toBe("all");
+    // 初期値が "all" だった頃は canSubmit（selectedTag !== ""）を素通りして
+    // tag_id 無しの「未分類」機材が登録できてしまっていた（回帰防止）
+    expect(result.current.selectedTag).toBe("");
   });
 
   it("setters update state", () => {
@@ -132,7 +134,10 @@ describe("useEquipmentRegistration - submit", () => {
 
   it("uploads file to Vercel Blob and posts the returned URL", async () => {
     const file = new File(["xxx"], "test.png", { type: "image/png" });
-    fetchMock.mockResolvedValue({ json: async () => ({ url: "https://blob.example/test.png" }) });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://blob.example/test.png" }),
+    });
     vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
 
     const params = { ...defaultParams, inputFileRef: makeInputRef([file]) };
@@ -172,6 +177,7 @@ describe("useEquipmentRegistration - submit", () => {
 
     act(() => {
       result.current.setEquipmentName("Camera");
+      result.current.setSelectedTag("Video");
     });
 
     await act(async () => {
@@ -180,5 +186,48 @@ describe("useEquipmentRegistration - submit", () => {
 
     expect(toastError).toHaveBeenCalledWith("機材登録ができません");
     expect(refetchEquipments).not.toHaveBeenCalled();
+  });
+
+  it("rejects submit when no existing category is selected", async () => {
+    const { result } = renderHook(() => useEquipmentRegistration(defaultParams));
+
+    act(() => {
+      result.current.setEquipmentName("Camera");
+    });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit();
+    });
+
+    expect(ok).toBe(false);
+    expect(toastError).toHaveBeenCalledWith("カテゴリを選択してください");
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it("aborts registration when the image upload responds with an error status", async () => {
+    // fetch は HTTP エラーで throw しないため、ok チェックが無いと {error} ボディのまま
+    // image:"" で登録が続行され「登録完了」と表示されていた（回帰防止）
+    const file = new File(["xxx"], "test.png", { type: "image/png" });
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({ error: "権限がありません。" }) });
+
+    const params = { ...defaultParams, inputFileRef: makeInputRef([file]) };
+    const { result } = renderHook(() => useEquipmentRegistration(params));
+
+    act(() => {
+      result.current.setEquipmentName("Camera");
+      result.current.setSelectedTag("Audio");
+    });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.submit();
+    });
+
+    expect(ok).toBe(false);
+    expect(toastError).toHaveBeenCalledWith(
+      "画像のアップロードに失敗しました。機材は登録されていません。"
+    );
+    expect(axios.post).not.toHaveBeenCalled();
   });
 });

--- a/app/(protected)/ems/manager/hooks/use-equipment-registration.test.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-registration.test.ts
@@ -14,6 +14,14 @@ vi.mock("sonner", () => ({
   },
 }));
 
+// 既定は素通し。縮小のロジック自体は lib/image-compress.test.ts が担う
+const { compressImageMock } = vi.hoisted(() => ({
+  compressImageMock: vi.fn(async (f: File) => f),
+}));
+vi.mock("@/lib/image-compress", () => ({
+  compressImage: (f: File) => compressImageMock(f),
+}));
+
 import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useEquipmentRegistration } from "./use-equipment-registration";
@@ -186,6 +194,43 @@ describe("useEquipmentRegistration - submit", () => {
 
     expect(toastError).toHaveBeenCalledWith("機材登録ができません");
     expect(refetchEquipments).not.toHaveBeenCalled();
+  });
+
+  it("uploads the compressed file with the compressed filename (name/body の整合)", async () => {
+    // compressImage は拡張子を .jpg に変えるため、filename= クエリと body が
+    // 同じ「縮小後ファイル」を指していることを固定する
+    const original = new File(["x".repeat(1024)], "photo.png", { type: "image/png" });
+    const compressed = new File(["y"], "photo.jpg", { type: "image/jpeg" });
+    compressImageMock.mockResolvedValueOnce(compressed);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://blob.example/photo.jpg" }),
+    });
+    vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
+
+    const params = { ...defaultParams, inputFileRef: makeInputRef([original]) };
+    const { result } = renderHook(() => useEquipmentRegistration(params));
+
+    act(() => {
+      result.current.setEquipmentName("Camera");
+      result.current.setSelectedTag("Audio");
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(compressImageMock).toHaveBeenCalledWith(original);
+    expect(fetchMock).toHaveBeenCalledWith("/api/upload?filename=photo.jpg", {
+      method: "POST",
+      body: compressed,
+      headers: managerAuthHeaders(),
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/lists",
+      expect.objectContaining({ image: "https://blob.example/photo.jpg" }),
+      expect.any(Object),
+    );
   });
 
   it("rejects submit when no existing category is selected", async () => {

--- a/app/(protected)/ems/manager/hooks/use-equipment-registration.test.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-registration.test.ts
@@ -1,10 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("axios", () => ({
-  default: { post: vi.fn() },
-}));
-
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 vi.mock("sonner", () => ({
@@ -22,7 +18,6 @@ vi.mock("@/lib/image-compress", () => ({
   compressImage: (f: File) => compressImageMock(f),
 }));
 
-import axios from "axios";
 import { managerAuthHeaders } from "@/lib/manager-auth";
 import { useEquipmentRegistration } from "./use-equipment-registration";
 
@@ -47,7 +42,6 @@ const defaultParams = {
 };
 
 beforeEach(() => {
-  vi.mocked(axios.post).mockReset();
   refetchEquipments.mockClear();
   resetImage.mockClear();
   alertMock.mockReset();
@@ -110,7 +104,7 @@ describe("useEquipmentRegistration - cancel", () => {
 
 describe("useEquipmentRegistration - submit", () => {
   it("posts to /api/lists without upload when no file selected", async () => {
-    vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
+    fetchMock.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() => useEquipmentRegistration(defaultParams));
 
@@ -124,17 +118,21 @@ describe("useEquipmentRegistration - submit", () => {
       await result.current.submit();
     });
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(axios.post).toHaveBeenCalledWith(
-      "/api/lists",
-      {
-        name: "Camera",
-        detail: "DSLR",
-        image: "",
-        tag_id: "2", // "Video" tag id
-      },
-      { headers: managerAuthHeaders() },
-    );
+    // アップロード API へは行かず、/api/lists への POST 1回のみ
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/lists");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      ...managerAuthHeaders(),
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      name: "Camera",
+      detail: "DSLR",
+      image: "",
+      tag_id: "2", // "Video" tag id
+    });
     expect(toastSuccess).toHaveBeenCalledWith("機材登録が完了しました");
     expect(refetchEquipments).toHaveBeenCalledOnce();
     expect(resetImage).toHaveBeenCalled();
@@ -142,11 +140,12 @@ describe("useEquipmentRegistration - submit", () => {
 
   it("uploads file to Vercel Blob and posts the returned URL", async () => {
     const file = new File(["xxx"], "test.png", { type: "image/png" });
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ url: "https://blob.example/test.png" }),
-    });
-    vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: "https://blob.example/test.png" }),
+      })
+      .mockResolvedValueOnce({ ok: true });
 
     const params = { ...defaultParams, inputFileRef: makeInputRef([file]) };
 
@@ -161,25 +160,24 @@ describe("useEquipmentRegistration - submit", () => {
       await result.current.submit();
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/upload?filename=test.png", {
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/upload?filename=test.png", {
       method: "POST",
       body: file,
       headers: managerAuthHeaders(),
     });
-    expect(axios.post).toHaveBeenCalledWith(
-      "/api/lists",
-      {
-        name: "Camera",
-        detail: "",
-        image: "https://blob.example/test.png",
-        tag_id: "1", // "Audio" tag id
-      },
-      { headers: managerAuthHeaders() },
-    );
+    const [listUrl, listInit] = fetchMock.mock.calls[1];
+    expect(listUrl).toBe("/api/lists");
+    expect(listInit.method).toBe("POST");
+    expect(JSON.parse(listInit.body)).toEqual({
+      name: "Camera",
+      detail: "",
+      image: "https://blob.example/test.png",
+      tag_id: "1", // "Audio" tag id
+    });
   });
 
   it("alerts on failure", async () => {
-    vi.mocked(axios.post).mockRejectedValue(new Error("network"));
+    fetchMock.mockRejectedValue(new Error("network"));
 
     const { result } = renderHook(() => useEquipmentRegistration(defaultParams));
 
@@ -202,11 +200,12 @@ describe("useEquipmentRegistration - submit", () => {
     const original = new File(["x".repeat(1024)], "photo.png", { type: "image/png" });
     const compressed = new File(["y"], "photo.jpg", { type: "image/jpeg" });
     compressImageMock.mockResolvedValueOnce(compressed);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ url: "https://blob.example/photo.jpg" }),
-    });
-    vi.mocked(axios.post).mockResolvedValue({ status: 200 } as never);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: "https://blob.example/photo.jpg" }),
+      })
+      .mockResolvedValueOnce({ ok: true });
 
     const params = { ...defaultParams, inputFileRef: makeInputRef([original]) };
     const { result } = renderHook(() => useEquipmentRegistration(params));
@@ -221,15 +220,15 @@ describe("useEquipmentRegistration - submit", () => {
     });
 
     expect(compressImageMock).toHaveBeenCalledWith(original);
-    expect(fetchMock).toHaveBeenCalledWith("/api/upload?filename=photo.jpg", {
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/upload?filename=photo.jpg", {
       method: "POST",
       body: compressed,
       headers: managerAuthHeaders(),
     });
-    expect(axios.post).toHaveBeenCalledWith(
-      "/api/lists",
-      expect.objectContaining({ image: "https://blob.example/photo.jpg" }),
-      expect.any(Object),
+    const [listUrl, listInit] = fetchMock.mock.calls[1];
+    expect(listUrl).toBe("/api/lists");
+    expect(JSON.parse(listInit.body)).toEqual(
+      expect.objectContaining({ image: "https://blob.example/photo.jpg" })
     );
   });
 
@@ -247,7 +246,7 @@ describe("useEquipmentRegistration - submit", () => {
 
     expect(ok).toBe(false);
     expect(toastError).toHaveBeenCalledWith("カテゴリを選択してください");
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("aborts registration when the image upload responds with an error status", async () => {
@@ -273,6 +272,8 @@ describe("useEquipmentRegistration - submit", () => {
     expect(toastError).toHaveBeenCalledWith(
       "画像のアップロードに失敗しました。機材は登録されていません。"
     );
-    expect(axios.post).not.toHaveBeenCalled();
+    // アップロードの1回のみで、/api/lists への POST には到達しない
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/upload?filename=test.png");
   });
 });

--- a/app/(protected)/ems/manager/hooks/use-equipment-registration.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-registration.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import axios from "axios";
 import { useState } from "react";
 import { toast } from "sonner";
 import { managerAuthHeaders } from "@/lib/manager-auth";
@@ -64,16 +63,18 @@ export const useEquipmentRegistration = ({
         blob = (await responseVercel.json()) as { url: string };
       }
 
-      await axios.post(
-        "/api/lists",
-        {
+      const res = await fetch("/api/lists", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...managerAuthHeaders() },
+        body: JSON.stringify({
           name: equipmentName,
           detail: equipmentDetail,
           image: blob?.url || "",
           tag_id: tagId,
-        },
-        { headers: managerAuthHeaders() },
-      );
+        }),
+      });
+      // fetch は HTTP エラーで throw しないため、明示的に catch へ流す
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       toast.success("機材登録が完了しました");
       setSelectedTag("");
       await refetchEquipments();

--- a/app/(protected)/ems/manager/hooks/use-equipment-registration.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-registration.ts
@@ -21,7 +21,9 @@ export const useEquipmentRegistration = ({
 }: UseEquipmentRegistrationParams) => {
   const [equipmentName, setEquipmentName] = useState("");
   const [equipmentDetail, setEquipmentDetail] = useState("");
-  const [selectedTag, setSelectedTag] = useState("all");
+  // 初期値を "all" にしていた頃は、カテゴリ未選択でも canSubmit（selectedTag !== ""）を
+  // 素通りして tag_id: undefined の「未分類」機材が登録され、予約画面から消えていた。
+  const [selectedTag, setSelectedTag] = useState("");
 
   const cancel = () => {
     resetImage();
@@ -32,6 +34,14 @@ export const useEquipmentRegistration = ({
 
   const submit = async (): Promise<boolean> => {
     try {
+      // tag_id 無しで登録すると機材が部員の予約画面に表示されなくなるため、
+      // 実在するカテゴリが選ばれていることを送信時にも保証する。
+      const tagId = tags.find((tag) => tag.name === selectedTag)?.id;
+      if (tagId == null) {
+        toast.error("カテゴリを選択してください");
+        return false;
+      }
+
       // アップロード API（R2）の応答は { url } のみ（旧 Vercel Blob の PutBlobResult 依存を除去）
       let blob: { url: string } | null = null;
 
@@ -42,6 +52,12 @@ export const useEquipmentRegistration = ({
           body: file,
           headers: managerAuthHeaders(),
         });
+        // fetch は HTTP エラーでは throw しない。API のエラー応答 {error:...} も有効な JSON の
+        // ため、ここで止めないと写真なしの機材が「登録完了」と表示されてしまう。
+        if (!responseVercel.ok) {
+          toast.error("画像のアップロードに失敗しました。機材は登録されていません。");
+          return false;
+        }
         blob = (await responseVercel.json()) as { url: string };
       }
 
@@ -51,7 +67,7 @@ export const useEquipmentRegistration = ({
           name: equipmentName,
           detail: equipmentDetail,
           image: blob?.url || "",
-          tag_id: tags.find((tag) => tag.name === selectedTag)?.id,
+          tag_id: tagId,
         },
         { headers: managerAuthHeaders() },
       );

--- a/app/(protected)/ems/manager/hooks/use-equipment-registration.ts
+++ b/app/(protected)/ems/manager/hooks/use-equipment-registration.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 import { useState } from "react";
 import { toast } from "sonner";
 import { managerAuthHeaders } from "@/lib/manager-auth";
+import { compressImage } from "@/lib/image-compress";
 import type { Tag } from "./use-tags";
 
 export interface UseEquipmentRegistrationParams {
@@ -46,7 +47,9 @@ export const useEquipmentRegistration = ({
       let blob: { url: string } | null = null;
 
       if (inputFileRef.current?.files && inputFileRef.current.files.length > 0) {
-        const file = inputFileRef.current.files[0];
+        // スマホ写真の原寸（数MB）をそのまま置くと全部員がサムネイル表示のために
+        // 原寸を落とすことになるため、アップロード前に縮小する（失敗時は原本のまま）
+        const file = await compressImage(inputFileRef.current.files[0]);
         const responseVercel = await fetch(`/api/upload?filename=${file.name}`, {
           method: "POST",
           body: file,

--- a/app/(protected)/ems/manager/hooks/use-tags.test.ts
+++ b/app/(protected)/ems/manager/hooks/use-tags.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 
 describe("useTags", () => {
   it("starts with empty tags and isLoading=true", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useTags());
     expect(result.current.tags).toEqual([]);
     expect(result.current.categories).toEqual([]);
@@ -32,7 +32,7 @@ describe("useTags", () => {
       { id: "1", name: "Audio", color: "#ff0000" },
       { id: "2", name: "Video", color: "#00ff00" },
     ];
-    fetchMock.mockResolvedValue({ json: async () => data });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => data });
 
     const { result } = renderHook(() => useTags());
 
@@ -56,7 +56,7 @@ describe("useTags", () => {
   });
 
   it("refetch re-runs the fetch", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useTags());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -69,7 +69,7 @@ describe("useTags", () => {
 
   it("falls back to empty tags/categories on a non-array (401/500) body", async () => {
     // /api/tags が認証ゲートで {error} を返しても .map がクラッシュしないことを固定
-    fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ error: "認証されていません。" }) });
 
     const { result } = renderHook(() => useTags());
 

--- a/app/(protected)/ems/manager/hooks/use-tags.test.ts
+++ b/app/(protected)/ems/manager/hooks/use-tags.test.ts
@@ -1,11 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useTags } from "./use-tags";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/manager/hooks/use-tags.ts
+++ b/app/(protected)/ems/manager/hooks/use-tags.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 
 // manager ページでは API レスポンスの `id` を Select の value（string 必須）として
 // 直接使うため string で扱う。`@/types/domain` の Tag (id: number) との整合は別タスクで対応予定。
@@ -10,30 +10,8 @@ export interface Tag {
   color: string;
 }
 
+// /api/tags のキャッシュは use-categories / use-tags-list と共有される。
 export const useTags = () => {
-  const [tags, setTags] = useState<Tag[]>([]);
-  const [categories, setCategories] = useState<Tag[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  const refetch = async () => {
-    setIsLoading(true);
-    try {
-      const response = await fetch("/api/tags");
-      const data = await response.json();
-      // 401/500 の非配列ボディでも render の .map がクラッシュしないよう空配列にフォールバック
-      const safe = Array.isArray(data) ? data : [];
-      setTags(safe);
-      setCategories(safe);
-    } catch (error) {
-      console.error("Error fetching categories: ", error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    refetch();
-  }, []);
-
-  return { tags, categories, isLoading, refetch };
+  const { data, isLoading, refetch } = useCachedEndpoint<Tag>("/api/tags");
+  return { tags: data, categories: data, isLoading, refetch };
 };

--- a/app/(protected)/ems/manager/page.tsx
+++ b/app/(protected)/ems/manager/page.tsx
@@ -63,6 +63,7 @@ export default function ManagerPage() {
       categories={tags}
       onEdit={actions.editEquipment}
       onDelete={actions.deleteEquipment}
+      editingId={actions.isPending ? actions.loadingId : null}
     />
   );
 

--- a/app/(protected)/ems/mypage/_components/MyReservations.tsx
+++ b/app/(protected)/ems/mypage/_components/MyReservations.tsx
@@ -84,6 +84,8 @@ export function MyReservations() {
     items: GroupedItem[];
     rangeText: string;
   } | null>(null);
+  // 「終了した予約」は履歴が無限に溜まるため、既定は直近数件だけ表示する
+  const [showAllPast, setShowAllPast] = useState(false);
   const isDesktop = useIsDesktop();
 
   const todayIdx = todayJstDayIndex();
@@ -297,11 +299,15 @@ export function MyReservations() {
             </button>
           </div>
         ) : (
-          sections.map((sec) => (
+          sections.map((sec) => {
+            const isPast = sec.label === "終了した予約";
+            const collapsed = isPast && !showAllPast && sec.items.length > 5;
+            const visibleItems = collapsed ? sec.items.slice(0, 5) : sec.items;
+            return (
             <div key={sec.label} className="mb-4">
               <p className="mb-2 px-1 text-xs font-bold text-ink-muted">{sec.label}</p>
               <div className="flex flex-col gap-2.5">
-                {sec.items.map((g) => {
+                {visibleItems.map((g) => {
                   const active = g.startIdx <= todayIdx && g.endIdx >= todayIdx;
                   const badge = badgeOf(g, todayIdx);
                   const days = g.endIdx - g.startIdx + 1;
@@ -439,9 +445,19 @@ export function MyReservations() {
                     </div>
                   );
                 })}
+                {collapsed && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllPast(true)}
+                    className="h-10 rounded-xl border-[1.5px] border-line bg-white text-[12.5px] font-bold text-ink-muted transition-colors hover:bg-line-soft"
+                  >
+                    すべて表示（あと{sec.items.length - visibleItems.length}件）
+                  </button>
+                )}
               </div>
             </div>
-          ))
+            );
+          })
         )}
       </div>
 

--- a/app/(protected)/ems/mypage/_components/MyReservations.tsx
+++ b/app/(protected)/ems/mypage/_components/MyReservations.tsx
@@ -63,13 +63,23 @@ function badgeOf(g: Grouped, todayIdx: number): { tone: StatusTone; label: strin
 export function MyReservations() {
   const router = useRouter();
   const user = useCurrentUser();
-  const { filteredData, refetch } = useMyReserves({ userId: user?.id });
+  const {
+    filteredData,
+    isLoading: reservesLoading,
+    isError: reservesError,
+    refetch,
+  } = useMyReserves({ userId: user?.id });
   const { equipments, isLoading: eqLoading } = useEquipments();
   const { categories } = useCategories();
   const { pendingIds, borrow, borrowMany, giveBack, giveBackMany, cancel, cancelMany } =
     useReserveActions({ refetch });
   // キャンセル確認の対象。単体は items 1件、一括は複数件。
   const [cancelTarget, setCancelTarget] = useState<{
+    items: GroupedItem[];
+    rangeText: string;
+  } | null>(null);
+  // 返却確認の対象。返却は取り消せない操作（isRenting 4→2 の遷移が無い）なので確認を挟む。
+  const [returnTarget, setReturnTarget] = useState<{
     items: GroupedItem[];
     rangeText: string;
   } | null>(null);
@@ -143,22 +153,48 @@ export function MyReservations() {
     [barEvents, matrix, isDesktop]
   );
 
-  // カードのセクション分け（利用中/今後/終了）
+  // カードのセクション分け（要返却/利用中/今後/終了）
   const sections = useMemo(() => {
+    const overdue: Grouped[] = [];
     const active: Grouped[] = [];
     const upcoming: Grouped[] = [];
     const past: Grouped[] = [];
     groups.forEach((g) => {
-      if (g.endIdx < todayIdx) past.push(g);
-      else if (g.startIdx > todayIdx) upcoming.push(g);
-      else active.push(g);
+      const hasUnreturned = g.items.some((it) => it.isRenting === 2 || it.isRenting === 3);
+      if (g.endIdx < todayIdx && hasUnreturned) {
+        // 期限超過なのに未返却の予約。「終了した予約」の山に埋めると
+        // 本人がスクロールしない限り延滞に気づけないため、最上部に出す。
+        overdue.push(g);
+      } else if (g.endIdx < todayIdx) {
+        past.push(g);
+      } else if (g.startIdx > todayIdx) {
+        upcoming.push(g);
+      } else {
+        active.push(g);
+      }
     });
+    // 終了した予約は新しい順（「先週返したやつ」を探すのに全履歴を遡らせない）
+    past.reverse();
     return [
+      { label: "要返却（期限超過）", items: overdue },
       { label: "利用中・受取可", items: active },
       { label: "今後の予約", items: upcoming },
       { label: "終了した予約", items: past },
     ].filter((s) => s.items.length > 0);
   }, [groups, todayIdx]);
+
+  // ページ上部の延滞バナー用（未返却のまま期限を過ぎた機材の件数）
+  const overdueCount = useMemo(
+    () =>
+      groups.reduce(
+        (n, g) =>
+          g.endIdx < todayIdx
+            ? n + g.items.filter((it) => it.isRenting === 2 || it.isRenting === 3).length
+            : n,
+        0
+      ),
+    [groups, todayIdx]
+  );
 
   const goPrevMonth = () => {
     setViewMonth0((m) => (m === 0 ? 11 : m - 1));
@@ -169,7 +205,9 @@ export function MyReservations() {
     if (viewMonth0 === 11) setViewYear((y) => y + 1);
   };
 
-  if (eqLoading) {
+  // 予約の取得完了前に判定すると、予約がある部員にも「予約はまだありません。」が
+  // 一瞬表示されてしまうため、機材と予約の両方の完了を待つ。
+  if (eqLoading || reservesLoading) {
     return (
       <div className="space-y-3">
         <Skeleton className="h-[320px] w-full rounded-2xl" />
@@ -178,8 +216,49 @@ export function MyReservations() {
     );
   }
 
+  if (reservesError) {
+    return (
+      <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
+        <p className="text-sm font-bold text-ink">予約を読み込めませんでした。</p>
+        <p className="mt-1 text-[12.5px] text-ink-faint">
+          通信環境を確認して、もう一度お試しください。
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-4 h-10 rounded-xl bg-brand px-5 text-sm font-bold text-white"
+        >
+          再試行
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className="grid grid-cols-1 gap-5 md:grid-cols-[minmax(0,1fr)_380px] md:items-start">
+    <div>
+      {overdueCount > 0 && (
+        <div className="mb-4 flex items-center gap-2.5 rounded-2xl border border-[#FDA29B] bg-[#FEF3F2] px-4 py-3">
+          <svg
+            className="flex-none text-danger"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 9v4" />
+            <path d="M12 17h.01" />
+            <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+          </svg>
+          <p className="m-0 text-[13px] font-bold text-danger">
+            返却期限を過ぎた機材が {overdueCount}件 あります。「要返却」から返却してください。
+          </p>
+        </div>
+      )}
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-[minmax(0,1fr)_380px] md:items-start">
       {/* 自分の予定カレンダー */}
       <div className="rounded-2xl bg-white p-4 shadow-sm">
         <div className="mb-3 flex items-center justify-between px-1">
@@ -288,7 +367,7 @@ export function MyReservations() {
                                 <button
                                   type="button"
                                   disabled={pending}
-                                  onClick={() => giveBack(it.reserveId)}
+                                  onClick={() => setReturnTarget({ items: [it], rangeText })}
                                   className="h-7 flex-none rounded-lg border-[1.5px] border-brand px-2.5 text-[11px] font-bold text-brand transition-colors hover:bg-brand-faint disabled:opacity-50"
                                 >
                                   {pending ? "…" : "返却"}
@@ -332,7 +411,7 @@ export function MyReservations() {
                               type="button"
                               disabled={pendingIds.length > 0}
                               onClick={() =>
-                                giveBackMany(returnables.map((it) => it.reserveId))
+                                setReturnTarget({ items: returnables, rangeText })
                               }
                               className="h-7 rounded-lg border-[1.5px] border-brand px-2.5 text-[11px] font-bold text-brand transition-colors hover:bg-brand-faint disabled:opacity-50"
                             >
@@ -398,6 +477,42 @@ export function MyReservations() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* 返却確認。誤タップで即「返却済」になると本人が元に戻せない（4→2 の遷移が無い）ため、
+          キャンセルと同じく確認を挟む */}
+      <AlertDialog
+        open={returnTarget != null}
+        onOpenChange={(open) => !open && setReturnTarget(null)}
+      >
+        <AlertDialogContent className="max-w-[360px] rounded-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-[15px]">機材を返却しますか？</AlertDialogTitle>
+            <AlertDialogDescription className="text-[12.5px]">
+              {returnTarget?.items.length === 1
+                ? `「${returnTarget.items[0].name}」を返却済みにします。`
+                : `${returnTarget?.rangeText} の機材 ${returnTarget?.items.length}件（${returnTarget?.items
+                    .map((it) => it.name)
+                    .join("・")}）を返却済みにします。`}
+              機材は所定の場所に戻しましたか？この操作は元に戻せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>戻る</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (returnTarget) {
+                  const ids = returnTarget.items.map((it) => it.reserveId);
+                  void (ids.length === 1 ? giveBack(ids[0]) : giveBackMany(ids));
+                }
+                setReturnTarget(null);
+              }}
+            >
+              返却する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      </div>
     </div>
   );
 }

--- a/app/(protected)/ems/mypage/_components/MyReservations.tsx
+++ b/app/(protected)/ems/mypage/_components/MyReservations.tsx
@@ -67,6 +67,7 @@ export function MyReservations() {
     filteredData,
     isLoading: reservesLoading,
     isError: reservesError,
+    hasLoaded: reservesLoaded,
     refetch,
   } = useMyReserves({ userId: user?.id });
   const { equipments, isLoading: eqLoading } = useEquipments();
@@ -216,7 +217,10 @@ export function MyReservations() {
     );
   }
 
-  if (reservesError) {
+  // 全画面エラーは「一度も取得できていない」ときだけ。返却・キャンセル成功後の
+  // refetch が失敗したケースで画面ごと乗っ取ると、「返却しました」のトーストと
+  // エラー画面が同時に出る矛盾した状態になる（表示済みの一覧は維持する）。
+  if (reservesError && !reservesLoaded) {
     return (
       <div className="rounded-2xl bg-white p-8 text-center shadow-sm">
         <p className="text-sm font-bold text-ink">予約を読み込めませんでした。</p>

--- a/app/(protected)/ems/mypage/hooks/use-my-reserves.test.ts
+++ b/app/(protected)/ems/mypage/hooks/use-my-reserves.test.ts
@@ -1,10 +1,13 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useMyReserves } from "./use-my-reserves";
+import { clearClientCache } from "@/lib/client-cache";
 
 const fetchMock = vi.fn();
 
 beforeEach(() => {
+  // モジュールスコープのキャッシュがテスト間で漏れないように毎回破棄する
+  clearClientCache();
   vi.stubGlobal("fetch", fetchMock);
 });
 

--- a/app/(protected)/ems/mypage/hooks/use-my-reserves.test.ts
+++ b/app/(protected)/ems/mypage/hooks/use-my-reserves.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 
 describe("useMyReserves", () => {
   it("starts with empty filteredData and isLoading=true", () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
     expect(result.current.filteredData).toEqual([]);
     expect(result.current.isLoading).toBe(true);
@@ -27,7 +27,7 @@ describe("useMyReserves", () => {
   it("fetches only /api/reserves filtered by userId (no /api/lists duplication)", async () => {
     // サーバーが user_id=u1 で絞り込み済みのデータを返す想定（u2 は含めない）
     fetchMock.mockResolvedValueOnce({
-      json: async () => [
+      ok: true, json: async () => [
         { id: 100, user_id: "u1", start: new Date(), end: new Date(), list_id: 1, isRenting: 0 },
       ],
     });
@@ -47,7 +47,7 @@ describe("useMyReserves", () => {
   });
 
   it("returns empty filteredData when no reserves match userId", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // サーバーが0件
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] }); // サーバーが0件
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
 
@@ -57,7 +57,7 @@ describe("useMyReserves", () => {
   });
 
   it("refetch re-runs the fetch", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -70,7 +70,7 @@ describe("useMyReserves", () => {
   });
 
   it("refetches when userId becomes available after mount", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { rerender } = renderHook(({ userId }) => useMyReserves({ userId }), {
       initialProps: { userId: undefined as string | undefined },
@@ -83,7 +83,7 @@ describe("useMyReserves", () => {
   });
 
   it("sends an empty ?user_id= (server zero-match) when userId is undefined, never a bare /api/reserves", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/reserves?user_id= (サーバーが0件)
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] }); // /api/reserves?user_id= (サーバーが0件)
 
     renderHook(() => useMyReserves({ userId: undefined }));
 
@@ -94,7 +94,7 @@ describe("useMyReserves", () => {
   });
 
   it("does not crash and stays empty when the reserves response is not an array (5xx body)", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => ({ error: "boom" }) }); // 非配列
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ error: "boom" }) }); // 非配列
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
 

--- a/app/(protected)/ems/mypage/hooks/use-my-reserves.test.ts
+++ b/app/(protected)/ems/mypage/hooks/use-my-reserves.test.ts
@@ -14,20 +14,14 @@ afterEach(() => {
 });
 
 describe("useMyReserves", () => {
-  it("starts with empty filteredData and idToNameMap", () => {
+  it("starts with empty filteredData and isLoading=true", () => {
     fetchMock.mockResolvedValue({ json: async () => [] });
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
     expect(result.current.filteredData).toEqual([]);
-    expect(result.current.idToNameMap).toEqual({});
+    expect(result.current.isLoading).toBe(true);
   });
 
-  it("builds idToNameMap from /api/lists and filters /api/reserves by userId", async () => {
-    fetchMock.mockResolvedValueOnce({
-      json: async () => [
-        { id: 1, name: "Camera", detail: "", image: "", usable: true },
-        { id: 2, name: "Tripod", detail: "", image: "", usable: true },
-      ],
-    });
+  it("fetches only /api/reserves filtered by userId (no /api/lists duplication)", async () => {
     // サーバーが user_id=u1 で絞り込み済みのデータを返す想定（u2 は含めない）
     fetchMock.mockResolvedValueOnce({
       json: async () => [
@@ -39,68 +33,82 @@ describe("useMyReserves", () => {
 
     await waitFor(() => expect(result.current.filteredData).toHaveLength(1));
 
-    expect(result.current.idToNameMap).toEqual({ 1: "Camera", 2: "Tripod" });
     expect(result.current.filteredData[0].user_id).toBe("u1");
     expect(result.current.filteredData[0].id).toBe(100);
+    expect(result.current.isLoading).toBe(false);
     // 絞り込みがサーバー側 ?user_id= で行われることを保証する（スコープ担保）
     expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id=u1");
+    // 機材名の解決は useEquipments 側の責務。/api/lists の二重取得はしない
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/lists");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns empty filteredData when no reserves match userId", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/lists
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/reserves?user_id=u1 (サーバーが0件)
+    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // サーバーが0件
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.filteredData).toEqual([]);
   });
 
-  it("refetch re-runs both fetches", async () => {
+  it("refetch re-runs the fetch", async () => {
     fetchMock.mockResolvedValue({ json: async () => [] });
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     fetchMock.mockClear();
     await result.current.refetch();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenCalledWith("/api/lists");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id=u1");
   });
 
+  it("refetches when userId becomes available after mount", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    const { rerender } = renderHook(({ userId }) => useMyReserves({ userId }), {
+      initialProps: { userId: undefined as string | undefined },
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id="));
+
+    rerender({ userId: "u1" });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id=u1"));
+  });
+
   it("sends an empty ?user_id= (server zero-match) when userId is undefined, never a bare /api/reserves", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/lists
     fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/reserves?user_id= (サーバーが0件)
 
     renderHook(() => useMyReserves({ userId: undefined }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     // 全ユーザー予約の漏洩を防ぐため、userId 未確定でも必ず絞り込みクエリを送る
     expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id=");
     expect(fetchMock).not.toHaveBeenCalledWith("/api/reserves");
   });
 
   it("does not crash and stays empty when the reserves response is not an array (5xx body)", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/lists
     fetchMock.mockResolvedValueOnce({ json: async () => ({ error: "boom" }) }); // 非配列
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.filteredData).toEqual([]);
   });
 
-  it("does not crash when the lists response is not an array (5xx body)", async () => {
-    fetchMock.mockResolvedValueOnce({ json: async () => ({ error: "boom" }) }); // /api/lists 非配列
-    fetchMock.mockResolvedValueOnce({ json: async () => [] }); // /api/reserves
+  it("reports isError instead of a silent empty state when the fetch rejects", async () => {
+    // 以前は通信エラーで「予約はまだありません。」の誤表示のまま固まっていた（回帰防止）
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockRejectedValue(new Error("network down"));
 
     const { result } = renderHook(() => useMyReserves({ userId: "u1" }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    expect(result.current.idToNameMap).toEqual({});
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
     expect(result.current.filteredData).toEqual([]);
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/app/(protected)/ems/mypage/hooks/use-my-reserves.ts
+++ b/app/(protected)/ems/mypage/hooks/use-my-reserves.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
 
 export interface Reserve {
   id: number;
@@ -15,43 +15,17 @@ export interface UseMyReservesParams {
   userId: string | undefined;
 }
 
-// 自分の予約一覧の取得。機材名の解決は useEquipments 側が担うため、ここでは予約だけを取る。
-// 以前は /api/lists → /api/reserves の直列2往復（しかも lists は useEquipments と二重取得）で、
-// スケルトンが消えたあとに「予約はまだありません。」が一瞬誤表示される原因になっていた。
+// 自分の予約一覧。機材名の解決は useEquipments 側が担うため、ここでは予約だけを取る。
+// サーバー側で user_id 絞り込み（userId 未確定時は ?user_id= となりサーバーは該当0件を返す）。
+// userId がマウント後に確定した場合は URL が変わり、use-cached-endpoint が取り直す。
 export const useMyReserves = ({ userId }: UseMyReservesParams) => {
-  const [filteredData, setFilteredData] = useState<Reserve[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-  // 一度でも取得に成功したか。呼び出し側はこれで「初回ロード失敗（全画面エラー）」と
-  // 「返却・キャンセル成功後の再取得の失敗（表示中の一覧を維持）」を区別する。
-  const [hasLoaded, setHasLoaded] = useState(false);
-  const hasLoadedRef = useRef(false);
-
-  const refetch = useCallback(async () => {
-    // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
-    if (!hasLoadedRef.current) setIsLoading(true);
-    try {
-      // サーバー側で user_id 絞り込み（従来はクライアントで .filter していた）。
-      // userId 未確定時は ?user_id= となりサーバーは該当0件を返す（従来と同じ空表示）。
-      const response = await fetch(`/api/reserves?user_id=${encodeURIComponent(userId ?? "")}`);
-      const reservesData: Reserve[] = await response.json();
-      setFilteredData(Array.isArray(reservesData) ? reservesData : []);
-      setIsError(false);
-      hasLoadedRef.current = true;
-      setHasLoaded(true);
-    } catch (error) {
-      // 失敗を握りつぶすと「予約はまだありません。」の誤表示で固まるため、エラーとして返す
-      console.error("Error fetching my reserves:", error);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [userId]);
-
-  useEffect(() => {
-    // userId がマウント後に確定するケースでも取り直せるよう refetch(=userId) に依存させる
-    refetch();
-  }, [refetch]);
+  const {
+    data: filteredData,
+    isLoading,
+    isError,
+    hasLoaded,
+    refetch,
+  } = useCachedEndpoint<Reserve>(`/api/reserves?user_id=${encodeURIComponent(userId ?? "")}`);
 
   return { filteredData, isLoading, isError, hasLoaded, refetch };
 };

--- a/app/(protected)/ems/mypage/hooks/use-my-reserves.ts
+++ b/app/(protected)/ems/mypage/hooks/use-my-reserves.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface Reserve {
   id: number;
@@ -22,8 +22,14 @@ export const useMyReserves = ({ userId }: UseMyReservesParams) => {
   const [filteredData, setFilteredData] = useState<Reserve[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
+  // 一度でも取得に成功したか。呼び出し側はこれで「初回ロード失敗（全画面エラー）」と
+  // 「返却・キャンセル成功後の再取得の失敗（表示中の一覧を維持）」を区別する。
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const hasLoadedRef = useRef(false);
 
   const refetch = useCallback(async () => {
+    // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
+    if (!hasLoadedRef.current) setIsLoading(true);
     try {
       // サーバー側で user_id 絞り込み（従来はクライアントで .filter していた）。
       // userId 未確定時は ?user_id= となりサーバーは該当0件を返す（従来と同じ空表示）。
@@ -31,6 +37,8 @@ export const useMyReserves = ({ userId }: UseMyReservesParams) => {
       const reservesData: Reserve[] = await response.json();
       setFilteredData(Array.isArray(reservesData) ? reservesData : []);
       setIsError(false);
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
     } catch (error) {
       // 失敗を握りつぶすと「予約はまだありません。」の誤表示で固まるため、エラーとして返す
       console.error("Error fetching my reserves:", error);
@@ -45,5 +53,5 @@ export const useMyReserves = ({ userId }: UseMyReservesParams) => {
     refetch();
   }, [refetch]);
 
-  return { filteredData, isLoading, isError, refetch };
+  return { filteredData, isLoading, isError, hasLoaded, refetch };
 };

--- a/app/(protected)/ems/mypage/hooks/use-my-reserves.ts
+++ b/app/(protected)/ems/mypage/hooks/use-my-reserves.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export interface Reserve {
   id: number;
@@ -11,45 +11,39 @@ export interface Reserve {
   isRenting: number; // 0:予約中, 1:貸出可, 2:貸出中, 3:滞納
 }
 
-interface List {
-  id: number;
-  name: string;
-  detail: string;
-  image: string;
-  usable: boolean;
-}
-
 export interface UseMyReservesParams {
   userId: string | undefined;
 }
 
+// 自分の予約一覧の取得。機材名の解決は useEquipments 側が担うため、ここでは予約だけを取る。
+// 以前は /api/lists → /api/reserves の直列2往復（しかも lists は useEquipments と二重取得）で、
+// スケルトンが消えたあとに「予約はまだありません。」が一瞬誤表示される原因になっていた。
 export const useMyReserves = ({ userId }: UseMyReservesParams) => {
   const [filteredData, setFilteredData] = useState<Reserve[]>([]);
-  const [idToNameMap, setIdToNameMap] = useState<{ [key: number]: string }>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
 
-  const refetch = async () => {
-    const responseLists = await fetch("/api/lists");
-    const listsJson = await responseLists.json();
-    // 予約側(:下)と防御水準を揃える。5xx時に {error} を .reduce してクラッシュするのを防ぐ。
-    const reservesListsData: List[] = Array.isArray(listsJson) ? listsJson : [];
-
-    const nameMap: { [key: number]: string } = reservesListsData.reduce((map, item) => {
-      map[item.id] = item.name;
-      return map;
-    }, {} as { [key: number]: string });
-
-    setIdToNameMap(nameMap);
-
-    // サーバー側で user_id 絞り込み（従来はクライアントで .filter していた）。
-    // userId 未確定時は ?user_id= となりサーバーは該当0件を返す（従来と同じ空表示）。
-    const response = await fetch(`/api/reserves?user_id=${encodeURIComponent(userId ?? "")}`);
-    const reservesData: Reserve[] = await response.json();
-    setFilteredData(Array.isArray(reservesData) ? reservesData : []);
-  };
+  const refetch = useCallback(async () => {
+    try {
+      // サーバー側で user_id 絞り込み（従来はクライアントで .filter していた）。
+      // userId 未確定時は ?user_id= となりサーバーは該当0件を返す（従来と同じ空表示）。
+      const response = await fetch(`/api/reserves?user_id=${encodeURIComponent(userId ?? "")}`);
+      const reservesData: Reserve[] = await response.json();
+      setFilteredData(Array.isArray(reservesData) ? reservesData : []);
+      setIsError(false);
+    } catch (error) {
+      // 失敗を握りつぶすと「予約はまだありません。」の誤表示で固まるため、エラーとして返す
+      console.error("Error fetching my reserves:", error);
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
 
   useEffect(() => {
+    // userId がマウント後に確定するケースでも取り直せるよう refetch(=userId) に依存させる
     refetch();
-  }, []);
+  }, [refetch]);
 
-  return { filteredData, idToNameMap, refetch };
+  return { filteredData, isLoading, isError, refetch };
 };

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,16 +1,27 @@
+import { SessionProvider } from "next-auth/react";
+import { auth } from "@/auth";
+
 interface ProtectedLayoutProps {
     children: React.ReactNode;
 }
 
-// SessionProvider は app/layout.tsx（ルート）で一度だけ提供する。
-// 以前はここでも auth() + SessionProvider を重ねていたが、SSR ごとの auth() が1回増えるうえ、
-// visibilitychange のリスナーが二重登録される割に再取得結果は外側の Provider にしか
-// 反映されないため、二重化をやめた。認可自体は middleware が担う。
-const ProtectedLayout = ({ children }: ProtectedLayoutProps) => {
+// この SessionProvider はルート（app/layout.tsx）と二重だが、撤去してはいけない。
+// credentials ログインはサーバーアクションの redirect によるソフト遷移のため、
+// /auth/login 時点で session=null でマウントされたルートの Provider がそのまま残る。
+// next-auth の SessionProvider は props.session を useState の初期値にしか使わず、
+// null セッションはイベントでも再取得しないので、内側で auth() の新しいセッションを
+// 初期値に取る Provider がないと、ログイン直後から useSession が未認証のまま固定される
+// （マイページが空になり、ヘッダーが「ゲスト」になる）。
+// タブ復帰ごとの再取得は不要なので refetchOnWindowFocus だけ無効化する。
+const ProtectedLayout = async ({ children }: ProtectedLayoutProps) => {
+    const session = await auth();
+
     return (
-        <div className="h-full">
-            {children}
-        </div>
+        <SessionProvider session={session} refetchOnWindowFocus={false}>
+            <div className="h-full">
+                {children}
+            </div>
+        </SessionProvider>
     );
 }
 

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,19 +1,16 @@
-import { SessionProvider } from "next-auth/react";
-import { auth } from "@/auth";
-
 interface ProtectedLayoutProps {
     children: React.ReactNode;
 }
 
-const ProtectedLayout = async ({ children }: ProtectedLayoutProps) => {
-    const session = await auth();
-
+// SessionProvider は app/layout.tsx（ルート）で一度だけ提供する。
+// 以前はここでも auth() + SessionProvider を重ねていたが、SSR ごとの auth() が1回増えるうえ、
+// visibilitychange のリスナーが二重登録される割に再取得結果は外側の Provider にしか
+// 反映されないため、二重化をやめた。認可自体は middleware が担う。
+const ProtectedLayout = ({ children }: ProtectedLayoutProps) => {
     return (
-        <SessionProvider session={session}>
-            <div className="h-full">
-                {children}
-            </div>
-        </SessionProvider>
+        <div className="h-full">
+            {children}
+        </div>
     );
 }
 

--- a/app/(protected)/settings/_components/AccountSection.tsx
+++ b/app/(protected)/settings/_components/AccountSection.tsx
@@ -62,7 +62,9 @@ export function AccountSection() {
             toast.error(data.error);
           }
           if (data.success) {
-            update();
+            // 引数なしの update() は GET になり jwt コールバックが DB を再照会しない。
+            // update({}) の POST で trigger="update" を立てて最新値をセッションに反映する。
+            update({});
             setMessage({ kind: "success", text: data.success });
             toast.success(data.success);
           }

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -41,7 +41,9 @@ export default function SettingsPage() {
       if (result.success) {
         // セッション(JWT)を更新しないと、このカードやヘッダーの表示名が旧名のまま残り
         // 「保存に失敗した？」と見える（AccountSection の保存処理と同じパターン）。
-        await update();
+        // 引数なしの update() は GET になり jwt コールバックに trigger="update" が
+        // 渡らない（DB 再照会がスキップされる）ため、必ず update({}) で POST にする。
+        await update({});
         toast.success("プロフィールを保存しました");
       }
     });

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
 import { toast } from "sonner";
 import { UserRole } from "@prisma/client";
@@ -19,10 +19,18 @@ function initialOf(name?: string | null) {
 }
 
 export default function SettingsPage() {
+  const router = useRouter();
   const user = useCurrentUser();
   const role = useCurrentRole();
   const { update } = useSession();
   const { settings, isLoading, patch } = useUserSettings();
+
+  // 戻る先を /ems/mypage に固定すると、カレンダー等から来た場合に文脈が失われる。
+  // 履歴があれば来た画面へ、なければ（直リンク・PWA起動直後）マイ予約へ。
+  const goBack = () => {
+    if (window.history.length > 1) router.back();
+    else router.push("/ems/mypage");
+  };
 
   const [name, setName] = useState("");
   const [savingName, startNameSave] = useTransition();
@@ -56,11 +64,11 @@ export default function SettingsPage() {
       {/* ネイビーヘッダー */}
       <div className="bg-navy px-4 pb-4 pt-5">
         <div className="mx-auto flex max-w-xl items-center gap-2.5">
-          <Link href="/ems/mypage" aria-label="戻る" className="text-white/90 hover:text-white">
+          <button type="button" onClick={goBack} aria-label="戻る" className="text-white/90 hover:text-white">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
               <path d="M15 5l-7 7 7 7" />
             </svg>
-          </Link>
+          </button>
           <span className="text-lg font-black tracking-wide text-white">設定</span>
         </div>
       </div>

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from "react";
 import Link from "next/link";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import { toast } from "sonner";
 import { UserRole } from "@prisma/client";
 
@@ -21,6 +21,7 @@ function initialOf(name?: string | null) {
 export default function SettingsPage() {
   const user = useCurrentUser();
   const role = useCurrentRole();
+  const { update } = useSession();
   const { settings, isLoading, patch } = useUserSettings();
 
   const [name, setName] = useState("");
@@ -37,7 +38,12 @@ export default function SettingsPage() {
         role: (user?.role as UserRole) || UserRole.USER,
       });
       if (result.error) toast.error(result.error);
-      if (result.success) toast.success("プロフィールを保存しました");
+      if (result.success) {
+        // セッション(JWT)を更新しないと、このカードやヘッダーの表示名が旧名のまま残り
+        // 「保存に失敗した？」と見える（AccountSection の保存処理と同じパターン）。
+        await update();
+        toast.success("プロフィールを保存しました");
+      }
     });
   };
 
@@ -90,7 +96,7 @@ export default function SettingsPage() {
         <div className="rounded-2xl bg-white px-4 shadow-sm">
           <ToggleRow
             title="返却期限のリマインド"
-            desc="期限の前日と当日にお知らせ"
+            desc="返却期限の当日朝にお知らせ"
             checked={settings.notifyReturnReminder}
             disabled={isLoading}
             onChange={(v) => patch({ notifyReturnReminder: v })}
@@ -164,11 +170,16 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        {/* アカウント */}
-        <SectionLabel>アカウント</SectionLabel>
-        <div className="rounded-2xl bg-white p-4 shadow-sm">
-          <AccountSection />
-        </div>
+        {/* アカウント（メール・パスワード・2段階認証）。Google ログインのユーザーには
+            変更できる項目がなく AccountSection が null を返すため、見出しと空カードごと出さない */}
+        {user?.isOAuth !== true && (
+          <>
+            <SectionLabel>アカウント</SectionLabel>
+            <div className="rounded-2xl bg-white p-4 shadow-sm">
+              <AccountSection />
+            </div>
+          </>
+        )}
 
         {/* ログアウト */}
         <button

--- a/app/api/cron/return-reminders/route.ts
+++ b/app/api/cron/return-reminders/route.ts
@@ -1,7 +1,7 @@
 import { db } from '@/lib/db';
 import { notifyReturnReminder } from '@/lib/notify';
 import { NextResponse } from 'next/server';
-import moment from 'moment-timezone';
+import { todayJstAsUtcMidnight } from '@/lib/jst-date';
 
 /* 返却期限リマインダー（cron から叩かれる内部エンドポイント）。
  *
@@ -21,7 +21,7 @@ export async function GET(request: Request) {
 
     try {
         // 保存値は「JST 日付の UTC 00:00」。今日(JST)も同じ座標系に変換して等値比較する。
-        const todayJst = new Date(moment().tz('Asia/Tokyo').format('YYYY-MM-DD') + 'T00:00:00Z');
+        const todayJst = todayJstAsUtcMidnight();
 
         const reserves = await db.reserve.findMany({
             where: {

--- a/app/api/lists/[equipmentId]/route.test.ts
+++ b/app/api/lists/[equipmentId]/route.test.ts
@@ -1,17 +1,32 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { findUniqueMock, updateMock, deleteMock, currentUserMock, hasManagerAccessMock } =
-  vi.hoisted(() => ({
-    findUniqueMock: vi.fn(),
-    updateMock: vi.fn(),
-    deleteMock: vi.fn(),
-    currentUserMock: vi.fn(),
-    hasManagerAccessMock: vi.fn(),
-  }));
+const {
+  findUniqueMock,
+  updateMock,
+  deleteMock,
+  reserveCountMock,
+  reserveDeleteManyMock,
+  transactionMock,
+  currentUserMock,
+  hasManagerAccessMock,
+} = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+  updateMock: vi.fn(),
+  deleteMock: vi.fn(),
+  reserveCountMock: vi.fn(),
+  reserveDeleteManyMock: vi.fn(),
+  transactionMock: vi.fn(),
+  currentUserMock: vi.fn(),
+  hasManagerAccessMock: vi.fn(),
+}));
 
 vi.mock("@/lib/db", () => ({
-  db: { list: { findUnique: findUniqueMock, update: updateMock, delete: deleteMock } },
+  db: {
+    list: { findUnique: findUniqueMock, update: updateMock, delete: deleteMock },
+    reserve: { count: reserveCountMock, deleteMany: reserveDeleteManyMock },
+    $transaction: transactionMock,
+  },
 }));
 // GET はログイン必須。PUT/DELETE の hasManagerAccess 経由で currentRole も参照されうるため両方出す。
 vi.mock("@/lib/auth", () => ({
@@ -41,6 +56,12 @@ beforeEach(() => {
   findUniqueMock.mockReset();
   updateMock.mockReset();
   deleteMock.mockReset();
+  reserveCountMock.mockReset();
+  reserveCountMock.mockResolvedValue(0);
+  reserveDeleteManyMock.mockReset();
+  transactionMock.mockReset();
+  // db.$transaction([...]) は各操作の Promise を解決した配列を返す想定
+  transactionMock.mockImplementation(async (ops: Promise<unknown>[]) => Promise.all(ops));
   currentUserMock.mockReset();
   hasManagerAccessMock.mockReset();
   hasManagerAccessMock.mockResolvedValue(true);
@@ -108,13 +129,29 @@ describe("PUT /api/lists/[equipmentId]", () => {
 });
 
 describe("DELETE /api/lists/[equipmentId]", () => {
-  it("deletes without a pre-check query", async () => {
+  it("deletes the equipment together with its reserves (orphan cleanup)", async () => {
     deleteMock.mockResolvedValue({ id: 5 });
+    reserveDeleteManyMock.mockResolvedValue({ count: 2 });
 
     const res = await DELETE(deleteRequest(), params);
 
     expect(res.status).toBe(200);
     expect(findUniqueMock).not.toHaveBeenCalled();
+    // 機材だけ消すと予約が孤児化（マイページに「#5」表示）するため、まとめて削除する
+    expect(reserveDeleteManyMock).toHaveBeenCalledWith({ where: { list_id: 5 } });
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 and does not delete while the equipment is on loan (isRenting 2/3)", async () => {
+    reserveCountMock.mockResolvedValue(1);
+
+    const res = await DELETE(deleteRequest(), params);
+
+    expect(res.status).toBe(409);
+    expect(reserveCountMock).toHaveBeenCalledWith({
+      where: { list_id: 5, isRenting: { in: [2, 3] } },
+    });
+    expect(transactionMock).not.toHaveBeenCalled();
   });
 
   it("maps P2025 (record not found) to 404", async () => {

--- a/app/api/lists/[equipmentId]/route.test.ts
+++ b/app/api/lists/[equipmentId]/route.test.ts
@@ -6,27 +6,41 @@ const {
   updateMock,
   deleteMock,
   reserveCountMock,
+  reserveFindManyMock,
   reserveDeleteManyMock,
   transactionMock,
   currentUserMock,
   hasManagerAccessMock,
+  notifyInBackgroundMock,
+  notifyReservationCancelledMock,
 } = vi.hoisted(() => ({
   findUniqueMock: vi.fn(),
   updateMock: vi.fn(),
   deleteMock: vi.fn(),
   reserveCountMock: vi.fn(),
+  reserveFindManyMock: vi.fn(),
   reserveDeleteManyMock: vi.fn(),
   transactionMock: vi.fn(),
   currentUserMock: vi.fn(),
   hasManagerAccessMock: vi.fn(),
+  notifyInBackgroundMock: vi.fn(),
+  notifyReservationCancelledMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
   db: {
     list: { findUnique: findUniqueMock, update: updateMock, delete: deleteMock },
-    reserve: { count: reserveCountMock, deleteMany: reserveDeleteManyMock },
+    reserve: {
+      count: reserveCountMock,
+      findMany: reserveFindManyMock,
+      deleteMany: reserveDeleteManyMock,
+    },
     $transaction: transactionMock,
   },
+}));
+vi.mock("@/lib/notify", () => ({
+  notifyInBackground: notifyInBackgroundMock,
+  notifyReservationCancelled: (...a: unknown[]) => notifyReservationCancelledMock(...a),
 }));
 // GET はログイン必須。PUT/DELETE の hasManagerAccess 経由で currentRole も参照されうるため両方出す。
 vi.mock("@/lib/auth", () => ({
@@ -58,6 +72,10 @@ beforeEach(() => {
   deleteMock.mockReset();
   reserveCountMock.mockReset();
   reserveCountMock.mockResolvedValue(0);
+  reserveFindManyMock.mockReset();
+  reserveFindManyMock.mockResolvedValue([]);
+  notifyInBackgroundMock.mockReset();
+  notifyReservationCancelledMock.mockReset();
   reserveDeleteManyMock.mockReset();
   transactionMock.mockReset();
   // db.$transaction([...]) は各操作の Promise を解決した配列を返す想定
@@ -160,5 +178,37 @@ describe("DELETE /api/lists/[equipmentId]", () => {
     const res = await DELETE(deleteRequest(), params);
 
     expect(res.status).toBe(404);
+  });
+
+  it("notifies owners of upcoming reserves that get cancelled by the deletion", async () => {
+    // 単発キャンセル（DELETE /api/reserves/[id]）と同じ「管理者による取り消しは
+    // 持ち主へ通知する」ポリシーを、機材削除経由の一括取り消しにも適用する
+    deleteMock.mockResolvedValue({ id: 5 });
+    reserveDeleteManyMock.mockResolvedValue({ count: 2 });
+    findUniqueMock.mockResolvedValue({ name: "Camera" });
+    const upcoming = [
+      { id: 100, user_id: "u1", list_id: 5, start: new Date(), end: new Date() },
+      { id: 101, user_id: "u2", list_id: 5, start: new Date(), end: new Date() },
+    ];
+    reserveFindManyMock.mockResolvedValue(upcoming);
+
+    const res = await DELETE(deleteRequest(), params);
+
+    expect(res.status).toBe(200);
+    // 機材名は List 行が消える前に控えたものを渡す（削除後は引けない）
+    expect(notifyReservationCancelledMock).toHaveBeenCalledTimes(2);
+    expect(notifyReservationCancelledMock).toHaveBeenCalledWith(upcoming[0], "Camera");
+    expect(notifyReservationCancelledMock).toHaveBeenCalledWith(upcoming[1], "Camera");
+    expect(notifyInBackgroundMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify when there are no upcoming reserves", async () => {
+    deleteMock.mockResolvedValue({ id: 5 });
+    reserveDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    const res = await DELETE(deleteRequest(), params);
+
+    expect(res.status).toBe(200);
+    expect(notifyReservationCancelledMock).not.toHaveBeenCalled();
   });
 });

--- a/app/api/lists/[equipmentId]/route.test.ts
+++ b/app/api/lists/[equipmentId]/route.test.ts
@@ -1,28 +1,49 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { findUniqueMock, currentUserMock } = vi.hoisted(() => ({
-  findUniqueMock: vi.fn(),
-  currentUserMock: vi.fn(),
-}));
+const { findUniqueMock, updateMock, deleteMock, currentUserMock, hasManagerAccessMock } =
+  vi.hoisted(() => ({
+    findUniqueMock: vi.fn(),
+    updateMock: vi.fn(),
+    deleteMock: vi.fn(),
+    currentUserMock: vi.fn(),
+    hasManagerAccessMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/db", () => ({
-  db: { list: { findUnique: findUniqueMock } },
+  db: { list: { findUnique: findUniqueMock, update: updateMock, delete: deleteMock } },
 }));
 // GET はログイン必須。PUT/DELETE の hasManagerAccess 経由で currentRole も参照されうるため両方出す。
 vi.mock("@/lib/auth", () => ({
   currentUser: () => currentUserMock(),
   currentRole: vi.fn(),
 }));
+vi.mock("@/lib/api-auth", () => ({
+  hasManagerAccess: () => hasManagerAccessMock(),
+}));
 
-import { GET } from "./route";
+import { DELETE, GET, PUT } from "./route";
 
 const getRequest = () => new Request("http://localhost/api/lists/5");
+const putRequest = (body: Record<string, unknown> = { name: "Camera" }) =>
+  new Request("http://localhost/api/lists/5", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+const deleteRequest = () => new Request("http://localhost/api/lists/5", { method: "DELETE" });
 const params = { params: Promise.resolve({ equipmentId: "5" }) };
+
+// update/delete が対象なしで投げる Prisma エラー（事前 findUnique を省いた分、ここで 404 に落とす）
+const p2025 = Object.assign(new Error("Record not found"), { code: "P2025" });
 
 beforeEach(() => {
   findUniqueMock.mockReset();
+  updateMock.mockReset();
+  deleteMock.mockReset();
   currentUserMock.mockReset();
+  hasManagerAccessMock.mockReset();
+  hasManagerAccessMock.mockResolvedValue(true);
 });
 
 describe("GET /api/lists/[equipmentId]", () => {
@@ -50,6 +71,56 @@ describe("GET /api/lists/[equipmentId]", () => {
     findUniqueMock.mockResolvedValue(null);
 
     const res = await GET(getRequest(), params);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PUT /api/lists/[equipmentId]", () => {
+  it("updates without a pre-check query", async () => {
+    updateMock.mockResolvedValue({ id: 5, name: "Camera" });
+
+    const res = await PUT(putRequest(), params);
+
+    expect(res.status).toBe(200);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 5 } }),
+    );
+  });
+
+  it("maps P2025 (record not found) to 404", async () => {
+    updateMock.mockRejectedValue(p2025);
+
+    const res = await PUT(putRequest(), params);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 without manager access", async () => {
+    hasManagerAccessMock.mockResolvedValue(false);
+
+    const res = await PUT(putRequest(), params);
+
+    expect(res.status).toBe(403);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/lists/[equipmentId]", () => {
+  it("deletes without a pre-check query", async () => {
+    deleteMock.mockResolvedValue({ id: 5 });
+
+    const res = await DELETE(deleteRequest(), params);
+
+    expect(res.status).toBe(200);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("maps P2025 (record not found) to 404", async () => {
+    deleteMock.mockRejectedValue(p2025);
+
+    const res = await DELETE(deleteRequest(), params);
 
     expect(res.status).toBe(404);
   });

--- a/app/api/lists/[equipmentId]/route.ts
+++ b/app/api/lists/[equipmentId]/route.ts
@@ -88,10 +88,26 @@ export async function DELETE(request: Request, { params }: Params) {
             return NextResponse.json({ error: '無効なIDです。' }, { status: 400 });
         }
 
-        // PUT と同じく事前確認なしで削除し、対象なしは P2025 で 404 に落とす。
-        const deleteEquipment = await db.list.delete({
-            where: { id: equipmentId }
+        // 貸出中・滞納（機材が部員の手元にある）の機材は削除させない。
+        // 削除すると「機材は手元にあるのに記録が消えた」状態になり在庫管理が壊れる。
+        const activeCount = await db.reserve.count({
+            where: { list_id: equipmentId, isRenting: { in: [2, 3] } },
         });
+        if (activeCount > 0) {
+            return NextResponse.json(
+                { error: '貸出中の機材は削除できません。返却された後に削除してください。' },
+                { status: 409 }
+            );
+        }
+
+        // 機材だけ消すと予約が孤児化し、部員のマイページに「#42」のような
+        // 機材名なしの予約が残り続けるため、関連予約もまとめて削除する
+        //（Reserve.list_id は FK なしの Int? なので DB 側の cascade は効かない）。
+        // 対象なしは P2025 で 404 に落とす。
+        const [, deleteEquipment] = await db.$transaction([
+            db.reserve.deleteMany({ where: { list_id: equipmentId } }),
+            db.list.delete({ where: { id: equipmentId } }),
+        ]);
 
         return NextResponse.json(deleteEquipment, { status: 200 });
     } catch (error) {

--- a/app/api/lists/[equipmentId]/route.ts
+++ b/app/api/lists/[equipmentId]/route.ts
@@ -1,6 +1,8 @@
 import { db } from '@/lib/db';
 import { hasManagerAccess } from '@/lib/api-auth';
 import { currentUser } from '@/lib/auth';
+import { notifyInBackground, notifyReservationCancelled } from '@/lib/notify';
+import { todayJstAsUtcMidnight } from '@/lib/jst-date';
 import { NextResponse } from 'next/server';
 
 interface Params {
@@ -100,6 +102,21 @@ export async function DELETE(request: Request, { params }: Params) {
             );
         }
 
+        // 削除で消える「今後の予約」の持ち主へ取り消し通知を送るため、削除前に控える
+        //（単発キャンセル DELETE /api/reserves/[id] と同じ通知ポリシー。
+        //  機材名も List 行が消える前にここで取得しておく）。
+        const upcoming = await db.reserve.findMany({
+            where: {
+                list_id: equipmentId,
+                user_id: { not: null },
+                end: { gte: todayJstAsUtcMidnight() },
+            },
+        });
+        const equipmentName = upcoming.length > 0
+            ? ((await db.list.findUnique({ where: { id: equipmentId }, select: { name: true } }))
+                ?.name ?? undefined)
+            : undefined;
+
         // 機材だけ消すと予約が孤児化し、部員のマイページに「#42」のような
         // 機材名なしの予約が残り続けるため、関連予約もまとめて削除する
         //（Reserve.list_id は FK なしの Int? なので DB 側の cascade は効かない）。
@@ -108,6 +125,10 @@ export async function DELETE(request: Request, { params }: Params) {
             db.reserve.deleteMany({ where: { list_id: equipmentId } }),
             db.list.delete({ where: { id: equipmentId } }),
         ]);
+
+        for (const r of upcoming) {
+            notifyInBackground(notifyReservationCancelled(r, equipmentName));
+        }
 
         return NextResponse.json(deleteEquipment, { status: 200 });
     } catch (error) {

--- a/app/api/lists/[equipmentId]/route.ts
+++ b/app/api/lists/[equipmentId]/route.ts
@@ -54,15 +54,8 @@ export async function PUT(request: Request, { params }: Params) {
             return NextResponse.json({ error: '無効なIDです。' }, { status: 400 });
         }
 
-        const equipmentData = await db.list.findUnique({
-            where: { id: equipmentId },
-        });
-
-        if (!equipmentData) {
-            return NextResponse.json({ error: 'データが見つかりませんでした。' }, { status: 404 });
-        }
-
-        // 機材データを更新
+        // 事前の findUnique による存在確認はせず、対象なしは P2025 で 404 に落とす
+        // （リクエストごとに新規接続を張る構成では DB 1往復の削減が効く）。
         const updatedEquipment = await db.list.update({
             where: { id: equipmentId },
             data: {
@@ -75,8 +68,11 @@ export async function PUT(request: Request, { params }: Params) {
 
         return NextResponse.json(updatedEquipment, { status: 200 });
     } catch (error) {
+        if ((error as { code?: string })?.code === 'P2025') {
+            return NextResponse.json({ error: 'データが見つかりませんでした。' }, { status: 404 });
+        }
         console.error('エラー詳細:', error);
-        return NextResponse.json({ error: 'データの取得に失敗しました。' }, { status: 500 });
+        return NextResponse.json({ error: 'データの更新に失敗しました。' }, { status: 500 });
     }
 }
 
@@ -92,22 +88,17 @@ export async function DELETE(request: Request, { params }: Params) {
             return NextResponse.json({ error: '無効なIDです。' }, { status: 400 });
         }
 
-        const equipmentData = await db.list.findUnique({
-            where: { id: equipmentId },
-        });
-
-        if (!equipmentData) {
-            return NextResponse.json({ error: 'データが見つかりませんでした。' }, { status: 404 });
-        }
-
-        // 機材データを削除
+        // PUT と同じく事前確認なしで削除し、対象なしは P2025 で 404 に落とす。
         const deleteEquipment = await db.list.delete({
             where: { id: equipmentId }
         });
 
         return NextResponse.json(deleteEquipment, { status: 200 });
     } catch (error) {
+        if ((error as { code?: string })?.code === 'P2025') {
+            return NextResponse.json({ error: 'データが見つかりませんでした。' }, { status: 404 });
+        }
         console.error('エラー詳細:', error);
-        return NextResponse.json({ error: 'データの取得に失敗しました。' }, { status: 500 });
+        return NextResponse.json({ error: 'データの削除に失敗しました。' }, { status: 500 });
     }
 }

--- a/app/api/reserves/[reserveId]/route.ts
+++ b/app/api/reserves/[reserveId]/route.ts
@@ -3,7 +3,7 @@ import { currentUser } from '@/lib/auth';
 import { notifyInBackground, notifyReservationCancelled } from '@/lib/notify';
 import { UserRole } from '@prisma/client';
 import { NextResponse } from 'next/server';
-import moment from 'moment-timezone';
+import { todayJstAsUtcMidnight } from '@/lib/jst-date';
 
 interface Params {
     params: Promise<{ reserveId: string }>;
@@ -60,7 +60,7 @@ export async function PATCH(request: Request, { params }: Params) {
 
         if (isRenting === 2) {
             // 借りる: 貸出期間内（JST 今日が start〜end、保存値は「JST日付のUTC 00:00」）のみ。
-            const todayJst = new Date(moment().tz('Asia/Tokyo').format('YYYY-MM-DD') + 'T00:00:00Z');
+            const todayJst = todayJstAsUtcMidnight();
             const result = await db.reserve.updateMany({
                 where: {
                     id: reserveId,

--- a/app/api/reserves/route.test.ts
+++ b/app/api/reserves/route.test.ts
@@ -277,6 +277,19 @@ describe("GET /api/reserves", () => {
     expect(findManyMock).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for a calendar-invalid from (month 13) instead of 500", async () => {
+    // 正規表現は桁数しか見ないため、Invalid Date が Prisma まで届いて 500 になっていた
+    const res = await GET(getRequest("?from=2026-13-01"));
+    expect(res.status).toBe(400);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a rollover date (Feb 30) instead of silently shifting to Mar 2", async () => {
+    const res = await GET(getRequest("?from=2026-02-30"));
+    expect(res.status).toBe(400);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for a malformed to and does not query", async () => {
     const res = await GET(getRequest("?to=notadate"));
     expect(res.status).toBe(400);

--- a/app/api/reserves/route.test.ts
+++ b/app/api/reserves/route.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import moment from "moment-timezone";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const findFirstMock = vi.fn();
@@ -41,8 +40,14 @@ const postRequest = (body: Record<string, unknown>) =>
   });
 
 // バリデーションはJSTの「今日」を基準にするため、期待値も同じ式で計算してTZ非依存にする
+// （日本にDSTはないので「ms加算→JSTで整形」は日単位の加算と等価）
 const jstDate = (offsetDays: number) =>
-  moment().tz("Asia/Tokyo").add(offsetDays, "days").format("YYYY-MM-DD");
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000));
 
 const validBody = () => ({
   user_id: "u1",
@@ -165,7 +170,7 @@ describe("POST /api/reserves", () => {
     // JST の (今日+1) 00:00 は UTC では前日 15:00
     const startJstDay = jstDate(1);
     const endJstDay = jstDate(2);
-    const startIso = moment.tz(startJstDay, "Asia/Tokyo").toISOString();
+    const startIso = new Date(`${startJstDay}T00:00:00+09:00`).toISOString();
 
     const res = await POST(
       postRequest({ user_id: "u1", list_id: 1, start: startIso, end: endJstDay }),

--- a/app/api/reserves/route.test.ts
+++ b/app/api/reserves/route.test.ts
@@ -244,4 +244,42 @@ describe("GET /api/reserves", () => {
     expect(res.status).toBe(400);
     expect(findManyMock).not.toHaveBeenCalled();
   });
+
+  // 期間フィルタ（保存値は「JST日付の UTC 00:00」なので同じ座標系で比較する）
+  it("filters by from (end >= from) for availability queries", async () => {
+    await GET(getRequest("?from=2026-07-06"));
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { end: { gte: new Date("2026-07-06T00:00:00Z") } },
+    });
+  });
+
+  it("filters by to (start <= to)", async () => {
+    await GET(getRequest("?to=2026-07-31"));
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { start: { lte: new Date("2026-07-31T00:00:00Z") } },
+    });
+  });
+
+  it("combines from/to with user_id", async () => {
+    await GET(getRequest("?user_id=u1&from=2026-07-01&to=2026-07-31"));
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        user_id: "u1",
+        end: { gte: new Date("2026-07-01T00:00:00Z") },
+        start: { lte: new Date("2026-07-31T00:00:00Z") },
+      },
+    });
+  });
+
+  it("returns 400 for a malformed from and does not query", async () => {
+    const res = await GET(getRequest("?from=2026/07/06"));
+    expect(res.status).toBe(400);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed to and does not query", async () => {
+    const res = await GET(getRequest("?to=notadate"));
+    expect(res.status).toBe(400);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
 });

--- a/app/api/reserves/route.ts
+++ b/app/api/reserves/route.ts
@@ -2,7 +2,7 @@ import { db } from '@/lib/db';
 import { currentUser } from '@/lib/auth';
 import { notifyInBackground, notifyReservationCreated } from '@/lib/notify';
 import { NextResponse } from 'next/server';
-import moment from 'moment-timezone';
+import { todayJstAsUtcMidnight } from '@/lib/jst-date';
 
 export async function GET(request: Request) {
     try {
@@ -104,7 +104,7 @@ export async function POST(request: Request) {
         }
 
         // 保存値は「JST日付のUTC 00:00」なので、今日(JST)も同じ座標系に変換して比較する
-        const todayJst = new Date(moment().tz('Asia/Tokyo').format('YYYY-MM-DD') + 'T00:00:00Z');
+        const todayJst = todayJstAsUtcMidnight();
         if (startDateTime < todayJst) {
             return NextResponse.json({ error: '予約開始日は今日以降にしてください。' }, { status: 400 });
         }

--- a/app/api/reserves/route.ts
+++ b/app/api/reserves/route.ts
@@ -4,6 +4,17 @@ import { notifyInBackground, notifyReservationCreated } from '@/lib/notify';
 import { NextResponse } from 'next/server';
 import { todayJstAsUtcMidnight } from '@/lib/jst-date';
 
+// YYYY-MM-DD を UTC 深夜0時の Date として厳密にパースする。
+// 正規表現だけだと「2026-13-01」（Invalid Date → Prisma が例外 → 500）や
+// 「2026-02-30」（3月2日へ静かに繰り上がる）が素通りするため、
+// 逆変換の一致まで確認して暦として実在する日付だけを受け付ける。
+function parseDateOnly(value: string): Date | null {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+    const date = new Date(`${value}T00:00:00Z`);
+    if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(value)) return null;
+    return date;
+}
+
 export async function GET(request: Request) {
     try {
         // ログイン必須。middleware 一枚依存をやめる defense-in-depth（DELETE と同じ currentUser パターン）。
@@ -43,18 +54,19 @@ export async function GET(request: Request) {
             }
             where.list_id = listId;
         }
-        const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
         if (fromParam !== null) {
-            if (!DATE_ONLY.test(fromParam)) {
+            const from = parseDateOnly(fromParam);
+            if (!from) {
                 return NextResponse.json({ error: 'from が不正です。' }, { status: 400 });
             }
-            where.end = { gte: new Date(`${fromParam}T00:00:00Z`) };
+            where.end = { gte: from };
         }
         if (toParam !== null) {
-            if (!DATE_ONLY.test(toParam)) {
+            const to = parseDateOnly(toParam);
+            if (!to) {
                 return NextResponse.json({ error: 'to が不正です。' }, { status: 400 });
             }
-            where.start = { lte: new Date(`${toParam}T00:00:00Z`) };
+            where.start = { lte: to };
         }
 
         const reserves = await db.reserve.findMany({ where });

--- a/app/api/reserves/route.ts
+++ b/app/api/reserves/route.ts
@@ -15,12 +15,23 @@ export async function GET(request: Request) {
         }
 
         // ?user_id= / ?list_id= の完全一致フィルタ（日付演算はしないのでタイムゾーン安全）。
+        // ?from= / ?to=（YYYY-MM-DD）は期間の重なりフィルタ:
+        //   from … end >= from（from 以降に掛かる予約。予約ウィザードの空き判定用）
+        //   to   … start <= to
+        // 保存値は「JST日付の UTC 00:00」なので、パラメータも同じ座標系に変換して比較する。
         // クエリ無し = 空 where = 全件 で従来の挙動を維持する（後方互換）。
         const { searchParams } = new URL(request.url);
         const userId = searchParams.get('user_id');
         const listIdParam = searchParams.get('list_id');
+        const fromParam = searchParams.get('from');
+        const toParam = searchParams.get('to');
 
-        const where: { user_id?: string; list_id?: number } = {};
+        const where: {
+            user_id?: string;
+            list_id?: number;
+            start?: { lte: Date };
+            end?: { gte: Date };
+        } = {};
         // 存在判定は !== null。?user_id= (空文字) は該当0件として扱い、全件漏洩を防ぐ。
         if (userId !== null) {
             where.user_id = userId;
@@ -31,6 +42,19 @@ export async function GET(request: Request) {
                 return NextResponse.json({ error: 'list_id が不正です。' }, { status: 400 });
             }
             where.list_id = listId;
+        }
+        const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+        if (fromParam !== null) {
+            if (!DATE_ONLY.test(fromParam)) {
+                return NextResponse.json({ error: 'from が不正です。' }, { status: 400 });
+            }
+            where.end = { gte: new Date(`${fromParam}T00:00:00Z`) };
+        }
+        if (toParam !== null) {
+            if (!DATE_ONLY.test(toParam)) {
+                return NextResponse.json({ error: 'to が不正です。' }, { status: 400 });
+            }
+            where.start = { lte: new Date(`${toParam}T00:00:00Z`) };
         }
 
         const reserves = await db.reserve.findMany({ where });

--- a/app/api/upload/route.test.ts
+++ b/app/api/upload/route.test.ts
@@ -79,7 +79,13 @@ describe("POST /api/upload", () => {
     const [key, body, opts] = putMock.mock.calls[0];
     expect(key).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-test\.png$/);
     expect(body).toBeInstanceOf(ArrayBuffer);
-    expect(opts).toMatchObject({ httpMetadata: { contentType: "image/png" } });
+    // toEqual で固定: キーは UUID 付きで不変なので immutable キャッシュが前提。
+    // ここが落ちる（キー名 typo・指定漏れ）と機材サムネイルが毎回オリジンまで
+    // 往復する静かな性能回帰になるため、追加キーを素通しする toMatchObject にしない。
+    expect(opts.httpMetadata).toEqual({
+      contentType: "image/png",
+      cacheControl: "public, max-age=31536000, immutable",
+    });
 
     // 応答は後方互換の { url }。カスタムドメイン + キーの絶対 URL。
     const responseBody = await res.json();

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -34,7 +34,13 @@ export async function POST(req: NextRequest) {
     const { env } = getCloudflareContext();
     const body = await req.arrayBuffer();
     await env.IMAGES_BUCKET.put(key, body, {
-      httpMetadata: { contentType: req.headers.get('content-type') ?? undefined },
+      httpMetadata: {
+        contentType: req.headers.get('content-type') ?? undefined,
+        // キーは UUID 付きで内容が変わることはないため immutable キャッシュが安全。
+        // これが無いと配信がヒューリスティックな短期キャッシュ頼みになり、
+        // 機材一覧を開くたびサムネイル20点強がオリジン（R2）まで往復していた。
+        cacheControl: 'public, max-age=31536000, immutable',
+      },
     });
 
     const url = `${baseUrl.replace(/\/$/, '')}/${key}`;

--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 // children は子のpage.tsx
 const AuthLayout = ({ children }: {children: React.ReactNode}) => {
   return (
-    <div className="h-full flex items-center justify-center
+    <div className="h-full flex items-center justify-center px-4
     bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))]
     from-sky-400 to-blue-800">
         {children}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+// サーバーレンダリング中の例外（DB 接続の瞬断など）で Next.js 既定の英語エラー画面
+//（再試行導線なし）に落ちないためのエラー境界。アプリのトーンで再試行を案内する。
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  console.error("Unhandled app error:", error);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface px-4">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-8 text-center shadow-sm">
+        <p className="text-sm font-bold text-ink">ページを読み込めませんでした。</p>
+        <p className="mt-1 text-[12.5px] text-ink-faint">
+          通信環境を確認して、もう一度お試しください。
+        </p>
+        <button
+          type="button"
+          onClick={() => reset()}
+          className="mt-4 h-10 w-full rounded-xl bg-brand text-sm font-bold text-white"
+        >
+          再試行
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,9 @@ export default async function RootLayout({
   //const user = await db.user.findMany
 
   return (
-    <SessionProvider session={session}>
+    // refetchOnWindowFocus はデフォルト有効だが、タブ復帰のたびに /api/auth/session への
+    // 往復（Worker 起動＋DBアクセス）が発生するため無効化。セッション情報は表示用途のみ。
+    <SessionProvider session={session} refetchOnWindowFocus={false}>
       <html lang="ja" className={notoSansJP.variable}>
         {/* headタグとその中にアイコンやテーマカラー、manifestを記述する */}
         <head>

--- a/auth.ts
+++ b/auth.ts
@@ -6,7 +6,7 @@ import { db } from "@/lib/db"
 import authConfig from "@/auth.config"
 import { getUserById } from "@/data/user"
 import { getTwoFactorConfirmationByUserId } from "@/data/two-factor-confirmation"
-import { getAccountByUserId } from "./data/account"
+import { refreshJwtToken } from "@/lib/jwt-refresh"
 
 export const {
   auth,
@@ -97,29 +97,9 @@ export const {
       return session;
     },
     async jwt({ token, user, trigger }) {
-      if (!token.sub) return token;
-
-      // DB照会はサインイン直後（user あり）と useSession().update() 実行時のみ。
-      // ここは auth() のたびに呼ばれるため、毎回照会すると全ページ・全APIに
-      // user/account の2クエリ分の遅延が上乗せされる。
-      // role 等を DB 側で直接変更した場合は再ログイン（または update()）で反映される。
-      if (!user && trigger !== "update") return token;
-
-      const existingUser = await getUserById(token.sub);
-
-      if (!existingUser) return token;
-
-      const existingAccount = await getAccountByUserId(
-        existingUser.id
-      );
-
-      token.isOAuth = !!existingAccount;
-      token.name = existingUser.name;
-      token.email = existingUser.email;
-      token.role = existingUser.role;
-      token.isTwoFactorEnabled = existingUser.isTwoFactorEnabled;
-
-      return token;
+      // 方針とテストは lib/jwt-refresh.ts を参照（通常リクエストは DB フリー、
+      // サインイン・update({})・15分経過時のみ user/account を再照会する）。
+      return refreshJwtToken({ token, user, trigger });
     }
   },
   adapter: PrismaAdapter(db),

--- a/auth.ts
+++ b/auth.ts
@@ -32,10 +32,6 @@ export const {
 
   callbacks: {
     async signIn({ user, account }) {
-      console.log({
-        user,
-        account,
-      })
       // Allow OAuth without email verification
       if (account?.provider !== "credentials") return true;
 
@@ -100,10 +96,14 @@ export const {
       /* 更新されたセッションを返す */
       return session;
     },
-    async jwt({ token, user, profile }) {
-      //console.log(token);
-      // console.log("I AM BEING CALLED AGAIN!")
+    async jwt({ token, user, trigger }) {
       if (!token.sub) return token;
+
+      // DB照会はサインイン直後（user あり）と useSession().update() 実行時のみ。
+      // ここは auth() のたびに呼ばれるため、毎回照会すると全ページ・全APIに
+      // user/account の2クエリ分の遅延が上乗せされる。
+      // role 等を DB 側で直接変更した場合は再ログイン（または update()）で反映される。
+      if (!user && trigger !== "update") return token;
 
       const existingUser = await getUserById(token.sub);
 

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -15,7 +15,7 @@ interface AbsEmsR2Bucket {
   put(
     key: string,
     value: ArrayBuffer | ArrayBufferView | ReadableStream | Blob | string | null,
-    options?: { httpMetadata?: { contentType?: string } },
+    options?: { httpMetadata?: { contentType?: string; cacheControl?: string } },
   ): Promise<unknown>;
 }
 

--- a/components/auth/card-wrapper.tsx
+++ b/components/auth/card-wrapper.tsx
@@ -25,8 +25,8 @@ export const CardWrapper = ({
     backButtonHref,
     showSocial
 }: CardWrapperProps) => {
+    // 固定幅だと CSS 幅360px級の端末（Galaxy 等）で左右が見切れるため max-width にする
     return (
-        {/* 固定幅だと CSS 幅360px級の端末（Galaxy 等）で左右が見切れるため max-width にする */}
         <Card className="w-full max-w-[370px] md:max-w-[450px] shadow-md">
             <CardHeader>
                 <Header label={headerLabel} />

--- a/components/auth/card-wrapper.tsx
+++ b/components/auth/card-wrapper.tsx
@@ -26,7 +26,8 @@ export const CardWrapper = ({
     showSocial
 }: CardWrapperProps) => {
     return (
-        <Card className="w-[370px] md:w-[450px] shadow-md">
+        {/* 固定幅だと CSS 幅360px級の端末（Galaxy 等）で左右が見切れるため max-width にする */}
+        <Card className="w-full max-w-[370px] md:max-w-[450px] shadow-md">
             <CardHeader>
                 <Header label={headerLabel} />
             </CardHeader>

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -44,9 +44,7 @@ export const LoginForm = () => {
         }
     });
 
-    //コンソールとかにEmailとPasswordの情報を送るやつ
     const onSubmit = (values: z.infer<typeof LoginSchema>) => {
-        // console.log(values);
         setError("");
         setSuccess("");
 
@@ -54,7 +52,10 @@ export const LoginForm = () => {
             login(values, callbackUrl)
                 .then((data) => {
                     if (data?.error) {
-                        form.reset();
+                        // 失敗時に form.reset() で全消去しない:
+                        // メール欄まで消えると毎回打ち直しになるうえ、2FA表示中は
+                        // 非表示の email/password が空になり「確認する」が無反応になる。
+                        if (showTwoFactor) form.resetField("code");
                         setError(data.error);
                     }
 
@@ -67,12 +68,8 @@ export const LoginForm = () => {
                         setShowTwoFactor(true);
                     }
                 })
-                .catch(() => setError("Something went wrong"));
+                .catch(() => setError("エラーが発生しました。時間をおいて再度お試しください。"));
         });
-
-        // APIを叩く時用
-        // axios.post("/your/api/route", values)
-        // .then
     }
 
     return (
@@ -115,7 +112,7 @@ export const LoginForm = () => {
                                     name="email"
                                     render={({ field }) => (
                                         <FormItem>
-                                            <FormLabel>Email</FormLabel>
+                                            <FormLabel>メールアドレス</FormLabel>
                                             <FormControl>
                                                 <Input
                                                     {...field}

--- a/components/auth/new-password-form.tsx
+++ b/components/auth/new-password-form.tsx
@@ -38,13 +38,9 @@ export const NewPasswordForm = () => {
         }
     });
 
-    //コンソールとかにEmailとPasswordの情報を送るやつ
     const onSubmit = (values: z.infer<typeof NewPasswordSchema>) => {
-        console.log(values);
         setError("");
         setSuccess("");
-
-        // console.log(values)
 
         startTransition(() => {
             newPassword(values, token)
@@ -53,10 +49,6 @@ export const NewPasswordForm = () => {
                     setSuccess(data?.success);
                 })
         });
-
-        // APIを叩く時用
-        // axios.post("/your/api/route", values)
-        // .then
     }
 
     return (
@@ -82,7 +74,7 @@ export const NewPasswordForm = () => {
                                             {...field}
                                             disabled={isPending}
                                             className="text-[16px]"
-                                            placeholder="*****"
+                                            placeholder="10文字以上で入力"
                                             type="password"
                                         />
                                     </FormControl>

--- a/components/auth/new-verification-form.tsx
+++ b/components/auth/new-verification-form.tsx
@@ -33,7 +33,7 @@ export const NewVerificationForm = () => {
                 setError(data.error);
             })
             .catch(() => {
-                setError("Something went wrong!");
+                setError("エラーが発生しました。時間をおいて再度お試しください。");
             })
     }, [token, success, error]);
 

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -90,7 +90,7 @@ export const RegisterForm = () => {
                             name="email"
                             render={({ field }) => (
                                 <FormItem>
-                                    <FormLabel>Email</FormLabel>
+                                    <FormLabel>メールアドレス</FormLabel>
                                     <FormControl>
                                         <Input
                                             {...field}
@@ -115,7 +115,7 @@ export const RegisterForm = () => {
                                             {...field}
                                             disabled={isPending}
                                             className="text-[16px]"
-                                            placeholder="******"
+                                            placeholder="10文字以上で入力"
                                             type="password"
                                         />
                                     </FormControl>

--- a/components/auth/reset-form.tsx
+++ b/components/auth/reset-form.tsx
@@ -34,13 +34,9 @@ export const ResetForm = () => {
         }
     });
 
-    //コンソールとかにEmailとPasswordの情報を送るやつ
     const onSubmit = (values: z.infer<typeof ResetSchema>) => {
-        console.log(values);
         setError("");
         setSuccess("");
-
-        // console.log(values)
 
         startTransition(() => {
             reset(values)
@@ -49,10 +45,6 @@ export const ResetForm = () => {
                     setSuccess(data?.success);
                 })
         });
-
-        // APIを叩く時用
-        // axios.post("/your/api/route", values)
-        // .then
     }
 
     return (
@@ -72,7 +64,7 @@ export const ResetForm = () => {
                             name="email"
                             render={({ field }) => (
                                 <FormItem>
-                                    <FormLabel>Email</FormLabel>
+                                    <FormLabel>メールアドレス</FormLabel>
                                     <FormControl>
                                         <Input
                                             {...field}

--- a/components/calendar/EquipmentGantt.tsx
+++ b/components/calendar/EquipmentGantt.tsx
@@ -48,9 +48,11 @@ export function EquipmentGantt<T = unknown>({
   const days = Array.from({ length: dayCount }, (_, i) => {
     const dayIndex = windowStartIdx + i;
     const d = dayIndexToUtcDate(dayIndex);
+    const dayOfMonth = d.getUTCDate();
     return {
       dayIndex,
-      dayOfMonth: d.getUTCDate(),
+      // 先頭列と月初は「M/D」で月を示す（窓が月境界をまたぐと日数字だけでは迷子になる）
+      label: i === 0 || dayOfMonth === 1 ? `${d.getUTCMonth() + 1}/${dayOfMonth}` : `${dayOfMonth}`,
       dow: DOW_LABELS[(((dayIndex + 4) % 7) + 7) % 7],
       isToday: dayIndex === todayIdx,
     };
@@ -75,7 +77,7 @@ export function EquipmentGantt<T = unknown>({
                 {d.dow}
               </p>
               <p className={cn("m-0 text-[11.5px] font-bold", d.isToday ? "text-brand-dark" : "text-ink")}>
-                {d.dayOfMonth}
+                {d.label}
               </p>
             </div>
           ))}

--- a/components/calendar/EventDetailPopover.tsx
+++ b/components/calendar/EventDetailPopover.tsx
@@ -11,8 +11,15 @@ export interface EventDetail {
   leftText: string; // 「あとN日」「今日返却」など
 }
 
-export function EventDetailPopover({ detail }: { detail: EventDetail }) {
-  const color = memberColor(detail.who);
+export function EventDetailPopover({
+  detail,
+  color: colorProp,
+}: {
+  detail: EventDetail;
+  /** バー側と同じ色割り当て（memberColorMap）を使う場合に渡す。省略時はハッシュ色 */
+  color?: string;
+}) {
+  const color = colorProp ?? memberColor(detail.who);
   return (
     <div className="rounded-2xl bg-navy p-[13px] px-[15px] text-white">
       <div className="flex items-center gap-2.5">

--- a/components/calendar/MemberChips.tsx
+++ b/components/calendar/MemberChips.tsx
@@ -14,6 +14,8 @@ export interface MemberChipsProps {
   className?: string;
   /** 折りたたみ時に表示するチップ数の上限（「すべて」を含む。おおよそ2行分） */
   collapseLimit?: number;
+  /** バー側と同じ色割り当て（memberColorMap）を使う場合に渡す。省略時はハッシュ色 */
+  colorOf?: (name: string) => string;
 }
 
 export function MemberChips({
@@ -22,6 +24,7 @@ export function MemberChips({
   onChange,
   className,
   collapseLimit = 10,
+  colorOf = memberColor,
 }: MemberChipsProps) {
   const [expanded, setExpanded] = useState(false);
 
@@ -31,7 +34,7 @@ export function MemberChips({
       name,
       label: name,
       initial: memberInitial(name),
-      color: memberColor(name),
+      color: colorOf(name),
     })),
   ];
 

--- a/components/calendar/MemberChips.tsx
+++ b/components/calendar/MemberChips.tsx
@@ -35,7 +35,7 @@ export function MemberChips({
     })),
   ];
 
-  const overflow = items.length > collapseLimit;
+  let overflow = items.length > collapseLimit;
   let shown = items;
   if (overflow && !expanded) {
     shown = items.slice(0, collapseLimit);
@@ -44,6 +44,8 @@ export function MemberChips({
       const selected = items.find((it) => it.name === value);
       if (selected) shown = [...shown, selected];
     }
+    // 選択中チップの補完で結局全員が表示されるケースでは「他0人」ボタンを出さない
+    if (shown.length === items.length) overflow = false;
   }
 
   return (

--- a/components/calendar/MonthGrid.tsx
+++ b/components/calendar/MonthGrid.tsx
@@ -64,7 +64,8 @@ export function MonthGrid<T = unknown>({
                   key={bar.key}
                   type="button"
                   onClick={() => onBarClick?.(bar)}
-                  className="absolute flex items-center overflow-hidden rounded-[5px] px-1.5 text-left transition-opacity"
+                  // before はタップ領域の拡張（見た目は変えずレーン間隔ぶんまで当たり判定を広げる）
+                  className="absolute flex items-center rounded-[5px] px-1.5 text-left transition-opacity before:absolute before:inset-x-0 before:-inset-y-[2px] before:content-['']"
                   style={{
                     left: `${bar.leftPct}%`,
                     width: `${bar.widthPct}%`,
@@ -75,7 +76,9 @@ export function MonthGrid<T = unknown>({
                     outline: selected ? "2px solid #101828" : "none",
                   }}
                 >
-                  <span className="truncate text-[8.5px] font-bold text-white md:text-[10.5px]">
+                  {/* 親の overflow-hidden はタップ領域拡張(before)を切ってしまうため、
+                      はみ出し制御はラベル側の min-w-0 + truncate で行う */}
+                  <span className="min-w-0 flex-1 truncate text-[8.5px] font-bold text-white md:text-[10.5px]">
                     {bar.label}
                   </span>
                 </button>

--- a/hooks/use-cached-endpoint.test.ts
+++ b/hooks/use-cached-endpoint.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 
 describe("useCachedEndpoint", () => {
   it("初回はスケルトン（isLoading）→取得完了でデータ表示", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 1 }] });
 
     const { result } = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
     expect(result.current.isLoading).toBe(true);
@@ -29,14 +29,14 @@ describe("useCachedEndpoint", () => {
 
   it("再マウント時はキャッシュを即表示し（スケルトンなし）、裏で再検証する", async () => {
     // タブ切り替えのたびに全画面スケルトンへ戻る問題（#47/#57）の回帰防止
-    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 1 }] });
 
     const first = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
     await waitFor(() => expect(first.result.current.hasLoaded).toBe(true));
     first.unmount();
 
     fetchMock.mockClear();
-    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }, { id: 2 }] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 1 }, { id: 2 }] });
 
     const second = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
     // キャッシュ即表示: ローディングに戻らず前回データが見えている
@@ -49,7 +49,7 @@ describe("useCachedEndpoint", () => {
   });
 
   it("同一URLへの同時リクエストは1本にまとめる", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     renderHook(() => {
       // 同じ画面内で複数フックが同じエンドポイントを見るケース
@@ -63,14 +63,14 @@ describe("useCachedEndpoint", () => {
   });
 
   it("URL が変わったら状態を組み直して取り直す（旧URLのデータを既読扱いしない）", async () => {
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
 
     const { result, rerender } = renderHook(({ url }) => useCachedEndpoint(url), {
       initialProps: { url: "/api/reserves?user_id=" },
     });
     await waitFor(() => expect(result.current.hasLoaded).toBe(true));
 
-    fetchMock.mockResolvedValue({ json: async () => [{ id: 9 }] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 9 }] });
     rerender({ url: "/api/reserves?user_id=u1" });
 
     await waitFor(() => expect(result.current.data).toEqual([{ id: 9 }]));
@@ -88,13 +88,13 @@ describe("useCachedEndpoint", () => {
     });
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    fetchMock.mockResolvedValueOnce({ json: async () => [{ id: "new" }] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [{ id: "new" }] });
     rerender({ url: "/api/reserves?user_id=u1" });
     await waitFor(() => expect(result.current.data).toEqual([{ id: "new" }]));
 
     // 旧URL（user_id=）の応答が遅れて届く
     await act(async () => {
-      resolveOld!({ json: async () => [{ id: "old" }] });
+      resolveOld!({ ok: true, json: async () => [{ id: "old" }] });
       await Promise.resolve();
     });
     expect(result.current.data).toEqual([{ id: "new" }]);
@@ -104,7 +104,7 @@ describe("useCachedEndpoint", () => {
     // エラー応答を「正常な空配列」としてキャッシュすると、誤った空表示が
     // タブセッション全体（他画面の同一エンドポイント）へ伝播するため、エラー扱いにする
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ error: "認証されていません。" }) });
 
     const { result } = renderHook(() => useCachedEndpoint("/api/lists"));
 
@@ -114,7 +114,7 @@ describe("useCachedEndpoint", () => {
     expect(result.current.hasLoaded).toBe(false);
 
     // 復旧後の再マウントは正常データを取得できる（汚染キャッシュが残っていない）
-    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 1 }] });
     const second = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
     expect(second.result.current.isLoading).toBe(true); // [] が「既読」扱いになっていない
     await waitFor(() => expect(second.result.current.data).toEqual([{ id: 1 }]));
@@ -143,7 +143,7 @@ describe("useCachedEndpoint", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
     // 変更後の再取得は新規リクエストとして飛ぶ
-    fetchMock.mockResolvedValueOnce({ json: async () => [{ id: "after" }] });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [{ id: "after" }] });
     await act(async () => {
       await result.current.refetch();
     });
@@ -152,7 +152,7 @@ describe("useCachedEndpoint", () => {
 
     // 変更前に発行された古い応答が後着しても、新しい結果を上書きしない
     await act(async () => {
-      resolveOld!({ json: async () => [{ id: "before" }] });
+      resolveOld!({ ok: true, json: async () => [{ id: "before" }] });
       await Promise.resolve();
     });
     expect(result.current.data).toEqual([{ id: "after" }]);
@@ -166,7 +166,7 @@ describe("useCachedEndpoint", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.hasLoaded).toBe(false);
 
-    fetchMock.mockResolvedValue({ json: async () => [] });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
     await act(async () => {
       await result.current.refetch();
     });

--- a/hooks/use-cached-endpoint.test.ts
+++ b/hooks/use-cached-endpoint.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCachedEndpoint } from "./use-cached-endpoint";
+import { clearClientCache } from "@/lib/client-cache";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  clearClientCache();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+describe("useCachedEndpoint", () => {
+  it("初回はスケルトン（isLoading）→取得完了でデータ表示", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }] });
+
+    const { result } = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual([{ id: 1 }]);
+    expect(result.current.hasLoaded).toBe(true);
+  });
+
+  it("再マウント時はキャッシュを即表示し（スケルトンなし）、裏で再検証する", async () => {
+    // タブ切り替えのたびに全画面スケルトンへ戻る問題（#47/#57）の回帰防止
+    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }] });
+
+    const first = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
+    await waitFor(() => expect(first.result.current.hasLoaded).toBe(true));
+    first.unmount();
+
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }, { id: 2 }] });
+
+    const second = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
+    // キャッシュ即表示: ローディングに戻らず前回データが見えている
+    expect(second.result.current.isLoading).toBe(false);
+    expect(second.result.current.data).toEqual([{ id: 1 }]);
+
+    // 裏で再検証されて最新に差し替わる
+    await waitFor(() => expect(second.result.current.data).toEqual([{ id: 1 }, { id: 2 }]));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("同一URLへの同時リクエストは1本にまとめる", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    renderHook(() => {
+      // 同じ画面内で複数フックが同じエンドポイントを見るケース
+      useCachedEndpoint("/api/tags");
+      useCachedEndpoint("/api/tags");
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("URL が変わったら状態を組み直して取り直す（旧URLのデータを既読扱いしない）", async () => {
+    fetchMock.mockResolvedValue({ json: async () => [] });
+
+    const { result, rerender } = renderHook(({ url }) => useCachedEndpoint(url), {
+      initialProps: { url: "/api/reserves?user_id=" },
+    });
+    await waitFor(() => expect(result.current.hasLoaded).toBe(true));
+
+    fetchMock.mockResolvedValue({ json: async () => [{ id: 9 }] });
+    rerender({ url: "/api/reserves?user_id=u1" });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 9 }]));
+    expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id=u1");
+  });
+
+  it("非配列ボディ（401/500 の {error}）は空配列にフォールバックする", async () => {
+    fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
+
+    const { result } = renderHook(() => useCachedEndpoint("/api/lists"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("初回失敗は isError、再試行成功で回復する", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error("down"));
+
+    const { result } = renderHook(() => useCachedEndpoint("/api/lists"));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.hasLoaded).toBe(false);
+
+    fetchMock.mockResolvedValue({ json: async () => [] });
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.hasLoaded).toBe(true);
+    consoleSpy.mockRestore();
+  });
+});

--- a/hooks/use-cached-endpoint.test.ts
+++ b/hooks/use-cached-endpoint.test.ts
@@ -77,14 +77,85 @@ describe("useCachedEndpoint", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/reserves?user_id=u1");
   });
 
-  it("非配列ボディ（401/500 の {error}）は空配列にフォールバックする", async () => {
+  it("旧URLの遅い応答が後着しても、新URLの表示を上書きしない", async () => {
+    let resolveOld: ((v: unknown) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveOld = resolve; })
+    );
+
+    const { result, rerender } = renderHook(({ url }) => useCachedEndpoint<{ id: string }>(url), {
+      initialProps: { url: "/api/reserves?user_id=" },
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    fetchMock.mockResolvedValueOnce({ json: async () => [{ id: "new" }] });
+    rerender({ url: "/api/reserves?user_id=u1" });
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "new" }]));
+
+    // 旧URL（user_id=）の応答が遅れて届く
+    await act(async () => {
+      resolveOld!({ json: async () => [{ id: "old" }] });
+      await Promise.resolve();
+    });
+    expect(result.current.data).toEqual([{ id: "new" }]);
+  });
+
+  it("非配列ボディ（401/500 の {error}）はキャッシュせず isError にする", async () => {
+    // エラー応答を「正常な空配列」としてキャッシュすると、誤った空表示が
+    // タブセッション全体（他画面の同一エンドポイント）へ伝播するため、エラー扱いにする
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     fetchMock.mockResolvedValue({ json: async () => ({ error: "認証されていません。" }) });
 
     const { result } = renderHook(() => useCachedEndpoint("/api/lists"));
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.data).toEqual([]);
-    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toEqual([]); // 表示用データは空のまま（.map 保護は維持）
+    expect(result.current.isError).toBe(true);
+    expect(result.current.hasLoaded).toBe(false);
+
+    // 復旧後の再マウントは正常データを取得できる（汚染キャッシュが残っていない）
+    fetchMock.mockResolvedValue({ json: async () => [{ id: 1 }] });
+    const second = renderHook(() => useCachedEndpoint<{ id: number }>("/api/lists"));
+    expect(second.result.current.isLoading).toBe(true); // [] が「既読」扱いになっていない
+    await waitFor(() => expect(second.result.current.data).toEqual([{ id: 1 }]));
+    consoleSpy.mockRestore();
+  });
+
+  it("HTTP エラーステータス（ok=false）はキャッシュせず isError にする", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => [] });
+
+    const { result } = renderHook(() => useCachedEndpoint("/api/lists"));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    consoleSpy.mockRestore();
+  });
+
+  it("refetch は進行中のリクエストに相乗りせず新規発行する（変更直後の巻き戻り防止）", async () => {
+    // 変更（POST/PATCH）成功後の refetch が「変更前に発行された GET」に相乗りすると、
+    // 変更前のスナップショットがキャッシュと画面に固定される
+    let resolveOld: ((v: unknown) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveOld = resolve; })
+    );
+
+    const { result } = renderHook(() => useCachedEndpoint<{ id: string }>("/api/tags"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // 変更後の再取得は新規リクエストとして飛ぶ
+    fetchMock.mockResolvedValueOnce({ json: async () => [{ id: "after" }] });
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual([{ id: "after" }]);
+
+    // 変更前に発行された古い応答が後着しても、新しい結果を上書きしない
+    await act(async () => {
+      resolveOld!({ json: async () => [{ id: "before" }] });
+      await Promise.resolve();
+    });
+    expect(result.current.data).toEqual([{ id: "after" }]);
   });
 
   it("初回失敗は isError、再試行成功で回復する", async () => {

--- a/hooks/use-cached-endpoint.ts
+++ b/hooks/use-cached-endpoint.ts
@@ -16,8 +16,10 @@ export interface CachedEndpointResult<T> {
 // 配列を返す社内 API 用の stale-while-revalidate フック。
 // - 初回: fetch 完了まで isLoading（スケルトン）
 // - 再マウント（タブ切り替え等）: キャッシュを即表示し、裏で再取得して差し替え
-// - 同一 URL への同時リクエストは lib/client-cache 側で1本にまとまる
-// - 非配列ボディ（401/500 の {error}）は空配列へフォールバック（呼び出し側の .map を守る）
+// - マウント時の再検証は同一 URL で1本にまとまる（lib/client-cache の重複排除）
+// - 公開している refetch は「変更直後の再取得」用なので、進行中のリクエストに
+//   相乗りせず必ず新規発行する（変更前のスナップショットを掴まないため）
+// - エラー応答（非配列ボディ・HTTPエラー）はキャッシュせず isError 経路に乗せる
 export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
   const initialCached = getCachedData<T[]>(url);
   const [data, setData] = useState<T[]>(initialCached ?? []);
@@ -26,32 +28,55 @@ export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
   const [hasLoaded, setHasLoaded] = useState(initialCached !== undefined);
   const hasLoadedRef = useRef(initialCached !== undefined);
   const urlRef = useRef(url);
+  // このフックが画面へ反映した最新のリクエスト世代。古い応答の後着を弾く
+  const appliedTicketRef = useRef(0);
 
-  const refetch = useCallback(async () => {
-    // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
-    if (!hasLoadedRef.current) setIsLoading(true);
-    try {
-      const fresh = await fetchAndCache<T[]>(url, async () => {
-        const res = await fetch(url);
-        const json = await res.json();
-        return Array.isArray(json) ? (json as T[]) : [];
-      });
-      // 応答待ちの間に URL が切り替わっていたら反映しない
-      // （旧URLの遅い応答が新URLの表示を上書きするレースを防ぐ。キャッシュには保存済み）
-      if (urlRef.current !== url) return;
-      setData(fresh);
-      setIsError(false);
-      hasLoadedRef.current = true;
-      setHasLoaded(true);
-    } catch (error) {
-      // 失敗を握りつぶすと空データの誤表示が恒久化するため、エラーとして呼び出し側へ返す
-      console.error(`Error fetching ${url}:`, error);
-      if (urlRef.current !== url) return;
-      setIsError(true);
-    } finally {
-      if (urlRef.current === url) setIsLoading(false);
-    }
-  }, [url]);
+  const runFetch = useCallback(
+    async (force: boolean) => {
+      // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
+      if (!hasLoadedRef.current) setIsLoading(true);
+      try {
+        const { data: fresh, ticket } = await fetchAndCache<T[]>(
+          url,
+          async () => {
+            const res = await fetch(url);
+            if (res.ok === false) {
+              throw new Error(`HTTP ${res.status} for ${url}`);
+            }
+            const json = await res.json();
+            if (!Array.isArray(json)) {
+              // 401/500 の {error} ボディ等。空配列として「正常」扱いでキャッシュすると
+              // 誤った空表示がタブ全体に伝播するため、エラーとして扱う
+              throw new Error(`unexpected non-array response for ${url}`);
+            }
+            return json as T[];
+          },
+          { force }
+        );
+        // 応答待ちの間に URL が切り替わっていたら反映しない
+        // （旧URLの遅い応答が新URLの表示を上書きするレースを防ぐ）
+        if (urlRef.current !== url) return;
+        // より新しいリクエストの結果を既に反映済みなら、古い応答は捨てる
+        if (ticket < appliedTicketRef.current) return;
+        appliedTicketRef.current = ticket;
+        setData(fresh);
+        setIsError(false);
+        hasLoadedRef.current = true;
+        setHasLoaded(true);
+      } catch (error) {
+        // 失敗を握りつぶすと空データの誤表示が恒久化するため、エラーとして呼び出し側へ返す
+        console.error(`Error fetching ${url}:`, error);
+        if (urlRef.current !== url) return;
+        setIsError(true);
+      } finally {
+        if (urlRef.current === url) setIsLoading(false);
+      }
+    },
+    [url]
+  );
+
+  // 変更直後の再取得・再試行ボタン用。進行中のリクエストに相乗りしない
+  const refetch = useCallback(() => runFetch(true), [runFetch]);
 
   useEffect(() => {
     // URL が変わったら（例: userId 確定でクエリが変わる）別リソースなので状態を組み直す。
@@ -65,9 +90,10 @@ export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
       setIsError(false);
       if (cached === undefined) setIsLoading(true);
     }
-    // キャッシュがあっても裏で必ず再検証する（stale-while-revalidate）
-    refetch();
-  }, [url, refetch]);
+    // キャッシュがあっても裏で必ず再検証する（stale-while-revalidate）。
+    // マウント時の再検証は force しない＝同一URLの同時マウントで1本にまとまる
+    void runFetch(false);
+  }, [url, runFetch]);
 
   return { data, isLoading, isError, hasLoaded, refetch };
 }

--- a/hooks/use-cached-endpoint.ts
+++ b/hooks/use-cached-endpoint.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchAndCache, getCachedData } from "@/lib/client-cache";
+
+export interface CachedEndpointResult<T> {
+  data: T[];
+  /** データが一度も無い状態での取得中（スケルトン表示用）。キャッシュがあれば false のまま */
+  isLoading: boolean;
+  isError: boolean;
+  /** 一度でも取得（またはキャッシュ表示）に成功したか。全画面エラーの出し分けに使う */
+  hasLoaded: boolean;
+  refetch: () => Promise<void>;
+}
+
+// 配列を返す社内 API 用の stale-while-revalidate フック。
+// - 初回: fetch 完了まで isLoading（スケルトン）
+// - 再マウント（タブ切り替え等）: キャッシュを即表示し、裏で再取得して差し替え
+// - 同一 URL への同時リクエストは lib/client-cache 側で1本にまとまる
+// - 非配列ボディ（401/500 の {error}）は空配列へフォールバック（呼び出し側の .map を守る）
+export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
+  const initialCached = getCachedData<T[]>(url);
+  const [data, setData] = useState<T[]>(initialCached ?? []);
+  const [isLoading, setIsLoading] = useState(initialCached === undefined);
+  const [isError, setIsError] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(initialCached !== undefined);
+  const hasLoadedRef = useRef(initialCached !== undefined);
+  const urlRef = useRef(url);
+
+  const refetch = useCallback(async () => {
+    // 初回（および初回失敗後の再試行）はスケルトンに戻して「押しても無反応」に見えないようにする
+    if (!hasLoadedRef.current) setIsLoading(true);
+    try {
+      const fresh = await fetchAndCache<T[]>(url, async () => {
+        const res = await fetch(url);
+        const json = await res.json();
+        return Array.isArray(json) ? (json as T[]) : [];
+      });
+      setData(fresh);
+      setIsError(false);
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
+    } catch (error) {
+      // 失敗を握りつぶすと空データの誤表示が恒久化するため、エラーとして呼び出し側へ返す
+      console.error(`Error fetching ${url}:`, error);
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [url]);
+
+  useEffect(() => {
+    // URL が変わったら（例: userId 確定でクエリが変わる）別リソースなので状態を組み直す。
+    // 旧 URL のデータを「読み込み済み」として見せると偽の空表示につながる。
+    if (urlRef.current !== url) {
+      urlRef.current = url;
+      const cached = getCachedData<T[]>(url);
+      hasLoadedRef.current = cached !== undefined;
+      setHasLoaded(cached !== undefined);
+      setData(cached ?? []);
+      setIsError(false);
+      if (cached === undefined) setIsLoading(true);
+    }
+    // キャッシュがあっても裏で必ず再検証する（stale-while-revalidate）
+    refetch();
+  }, [url, refetch]);
+
+  return { data, isLoading, isError, hasLoaded, refetch };
+}

--- a/hooks/use-cached-endpoint.ts
+++ b/hooks/use-cached-endpoint.ts
@@ -36,6 +36,9 @@ export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
         const json = await res.json();
         return Array.isArray(json) ? (json as T[]) : [];
       });
+      // 応答待ちの間に URL が切り替わっていたら反映しない
+      // （旧URLの遅い応答が新URLの表示を上書きするレースを防ぐ。キャッシュには保存済み）
+      if (urlRef.current !== url) return;
       setData(fresh);
       setIsError(false);
       hasLoadedRef.current = true;
@@ -43,9 +46,10 @@ export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
     } catch (error) {
       // 失敗を握りつぶすと空データの誤表示が恒久化するため、エラーとして呼び出し側へ返す
       console.error(`Error fetching ${url}:`, error);
+      if (urlRef.current !== url) return;
       setIsError(true);
     } finally {
-      setIsLoading(false);
+      if (urlRef.current === url) setIsLoading(false);
     }
   }, [url]);
 

--- a/hooks/use-cached-endpoint.ts
+++ b/hooks/use-cached-endpoint.ts
@@ -40,7 +40,7 @@ export function useCachedEndpoint<T>(url: string): CachedEndpointResult<T> {
           url,
           async () => {
             const res = await fetch(url);
-            if (res.ok === false) {
+            if (!res.ok) {
               throw new Error(`HTTP ${res.status} for ${url}`);
             }
             const json = await res.json();

--- a/lib/calendar/member-colors.test.ts
+++ b/lib/calendar/member-colors.test.ts
@@ -55,6 +55,16 @@ describe("memberColorMap", () => {
       expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
     }
   });
+
+  it("優先リスト（表示中の月の部員）は履歴が何人いても互いに異なる色になる", () => {
+    // 卒業生など履歴上の名前が一意枠(16色)を食いつぶしても、
+    // いま表示している月の部員同士は同色にならないことを固定する
+    const history = Array.from({ length: 30 }, (_, i) => `卒業生${i}`);
+    const current = ["現役A", "現役B", "現役C", "現役D"];
+    const map = memberColorMap([...history, ...current], current);
+    const currentColors = current.map((n) => map.get(n));
+    expect(new Set(currentColors).size).toBe(current.length);
+  });
 });
 
 describe("memberInitial", () => {

--- a/lib/calendar/member-colors.test.ts
+++ b/lib/calendar/member-colors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { memberColor, memberInitial } from "./member-colors";
+import { memberColor, memberColorMap, memberInitial } from "./member-colors";
 
 describe("memberColor", () => {
   it("同じ名前は常に同じ色（決定的）", () => {
@@ -15,6 +15,45 @@ describe("memberColor", () => {
   it("空/undefined はフォールバック色", () => {
     expect(memberColor(undefined)).toBe("#667085");
     expect(memberColor("")).toBe("#667085");
+  });
+});
+
+describe("memberColorMap", () => {
+  it("パレット数以内なら全員に異なる色を割り当てる（ハッシュ衝突を回避する）", () => {
+    // 素の memberColor では衝突することが分かっている組を含む名前群
+    const names = [
+      "川崎蒼汰",
+      "大森悠人",
+      "星野琉生",
+      "三浦ひな",
+      "青山太郎",
+      "佐藤花子",
+      "田中一郎",
+      "鈴木次郎",
+    ];
+    const map = memberColorMap(names);
+    const colors = [...map.values()];
+    expect(new Set(colors).size).toBe(names.length);
+  });
+
+  it("同じメンバー集合なら並び順に関係なく同じ割り当て（安定）", () => {
+    const a = memberColorMap(["川崎蒼汰", "星野琉生", "三浦ひな"]);
+    const b = memberColorMap(["三浦ひな", "川崎蒼汰", "星野琉生"]);
+    expect(Object.fromEntries(a)).toEqual(Object.fromEntries(b));
+  });
+
+  it("null/undefined/重複は無視する", () => {
+    const map = memberColorMap(["川崎蒼汰", null, undefined, "川崎蒼汰"]);
+    expect(map.size).toBe(1);
+  });
+
+  it("パレット数を超えても例外にならない（重複はやむなし）", () => {
+    const names = Array.from({ length: 30 }, (_, i) => `部員${i}`);
+    const map = memberColorMap(names);
+    expect(map.size).toBe(30);
+    for (const color of map.values()) {
+      expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
   });
 });
 

--- a/lib/calendar/member-colors.ts
+++ b/lib/calendar/member-colors.ts
@@ -13,6 +13,12 @@ const MEMBER_PALETTE = [
   "#EAAA08", // amber
   "#4E5BA6", // indigo-gray
   "#15B79E", // teal
+  "#9F1AB1", // magenta
+  "#3E4784", // dark indigo
+  "#B54708", // brown
+  "#0E7090", // dark cyan
+  "#C11574", // dark pink
+  "#66C61C", // lime
 ] as const;
 
 /** 文字列 → 安定した非負ハッシュ（djb2）。 */
@@ -28,6 +34,29 @@ function hashString(s: string): number {
 export function memberColor(name: string | null | undefined): string {
   if (!name) return "#667085";
   return MEMBER_PALETTE[hashString(name) % MEMBER_PALETTE.length];
+}
+
+/**
+ * 部員一覧に対して、できるだけ重複しない色割り当てを返す。
+ * 素のハッシュ剰余だと少人数でも高確率で衝突し（誕生日のパラドックス）、
+ * 月表示の「色＝人」の前提が崩れるため、各名前のハッシュ色を起点に
+ * 空いている色へ線形探索でずらす。パレット数を超えたら重複はやむなし。
+ * 名前を昇順ソートしてから割り当てるので、同じメンバー集合なら結果は安定
+ * （メンバーが増減すると他の人の色が変わり得るのは一意性とのトレードオフ）。
+ */
+export function memberColorMap(names: (string | null | undefined)[]): Map<string, string> {
+  const map = new Map<string, string>();
+  const unique = [...new Set(names.filter((n): n is string => !!n))].sort();
+  const used = new Set<number>();
+  for (const name of unique) {
+    let idx = hashString(name) % MEMBER_PALETTE.length;
+    if (used.size < MEMBER_PALETTE.length) {
+      while (used.has(idx)) idx = (idx + 1) % MEMBER_PALETTE.length;
+    }
+    used.add(idx);
+    map.set(name, MEMBER_PALETTE[idx]);
+  }
+  return map;
 }
 
 /** アバター等のイニシャル（先頭1文字）。 */

--- a/lib/calendar/member-colors.ts
+++ b/lib/calendar/member-colors.ts
@@ -41,21 +41,33 @@ export function memberColor(name: string | null | undefined): string {
  * 素のハッシュ剰余だと少人数でも高確率で衝突し（誕生日のパラドックス）、
  * 月表示の「色＝人」の前提が崩れるため、各名前のハッシュ色を起点に
  * 空いている色へ線形探索でずらす。パレット数を超えたら重複はやむなし。
- * 名前を昇順ソートしてから割り当てるので、同じメンバー集合なら結果は安定
+ *
+ * priorityNames には「いま表示している月の部員」を渡す。全履歴のユニーク部員が
+ * パレット数（16人）を超えても、先に割り当てる表示中の部員同士は一意性が守られる
+ * （卒業生など履歴上の名前が一意枠を食いつぶすのを防ぐ）。
+ * 各グループ内は名前昇順で割り当てるため、同じメンバー集合なら結果は安定
  * （メンバーが増減すると他の人の色が変わり得るのは一意性とのトレードオフ）。
  */
-export function memberColorMap(names: (string | null | undefined)[]): Map<string, string> {
+export function memberColorMap(
+  names: (string | null | undefined)[],
+  priorityNames: (string | null | undefined)[] = []
+): Map<string, string> {
   const map = new Map<string, string>();
-  const unique = [...new Set(names.filter((n): n is string => !!n))].sort();
   const used = new Set<number>();
-  for (const name of unique) {
-    let idx = hashString(name) % MEMBER_PALETTE.length;
-    if (used.size < MEMBER_PALETTE.length) {
-      while (used.has(idx)) idx = (idx + 1) % MEMBER_PALETTE.length;
+  const assign = (list: (string | null | undefined)[]) => {
+    const unique = [...new Set(list.filter((n): n is string => !!n))].sort();
+    for (const name of unique) {
+      if (map.has(name)) continue;
+      let idx = hashString(name) % MEMBER_PALETTE.length;
+      if (used.size < MEMBER_PALETTE.length) {
+        while (used.has(idx)) idx = (idx + 1) % MEMBER_PALETTE.length;
+      }
+      used.add(idx);
+      map.set(name, MEMBER_PALETTE[idx]);
     }
-    used.add(idx);
-    map.set(name, MEMBER_PALETTE[idx]);
-  }
+  };
+  assign(priorityNames);
+  assign(names);
   return map;
 }
 

--- a/lib/client-cache.ts
+++ b/lib/client-cache.ts
@@ -1,0 +1,40 @@
+// クライアント側の素朴な stale-while-revalidate キャッシュ。
+//
+// 以前は全フックが「マウント時に素の fetch」だったため、ヘッダーのタブを
+// 行き来するたびに同じマスタデータを取り直してスケルトンに戻っていた。
+// SWR / TanStack Query を入れるほどの規模ではないので、モジュールスコープの
+// Map で次の2つだけを担う:
+//   1. 再訪時（再マウント時）は前回データを即表示し、裏で再取得して差し替える
+//   2. 同一キーへの同時リクエストを1本にまとめる（重複排除）
+// キャッシュはタブを閉じるまで残るが、マウントごとに必ず再検証されるので
+// 古いデータが表示され続けることはない。
+
+const cache = new Map<string, unknown>();
+const inflight = new Map<string, Promise<unknown>>();
+
+export function getCachedData<T>(key: string): T | undefined {
+  return cache.get(key) as T | undefined;
+}
+
+export async function fetchAndCache<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  const pending = inflight.get(key);
+  if (pending) return pending as Promise<T>;
+
+  const p = (async () => {
+    try {
+      const data = await fetcher();
+      cache.set(key, data);
+      return data;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+  inflight.set(key, p);
+  return p;
+}
+
+/** テスト用: モジュールスコープのキャッシュと進行中リクエストを破棄する */
+export function clearClientCache() {
+  cache.clear();
+  inflight.clear();
+}

--- a/lib/client-cache.ts
+++ b/lib/client-cache.ts
@@ -10,31 +10,63 @@
 // 古いデータが表示され続けることはない。
 
 const cache = new Map<string, unknown>();
-const inflight = new Map<string, Promise<unknown>>();
+
+interface InflightEntry {
+  promise: Promise<{ data: unknown; ticket: number }>;
+  ticket: number;
+}
+const inflight = new Map<string, InflightEntry>();
+
+// リクエストの世代番号。「古いリクエストの遅い応答」が新しい結果を
+// 上書きしないよう、キャッシュへの書き込みは ticket の新しい順を保証する。
+let seq = 0;
+const lastWrittenTicket = new Map<string, number>();
 
 export function getCachedData<T>(key: string): T | undefined {
   return cache.get(key) as T | undefined;
 }
 
-export async function fetchAndCache<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
-  const pending = inflight.get(key);
-  if (pending) return pending as Promise<T>;
+export interface FetchAndCacheOptions {
+  /**
+   * 進行中の同一キーのリクエストに相乗りせず、必ず新規リクエストを発行する。
+   * 予約作成・返却・並べ替えなど「変更した直後の再取得」で使う。
+   * 相乗りすると、変更前にサーバーへ届いた GET の結果（変更前のスナップショット）を
+   * 受け取ってしまい、変更が巻き戻ったように見える。
+   */
+  force?: boolean;
+}
 
-  const p = (async () => {
+export async function fetchAndCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  options: FetchAndCacheOptions = {}
+): Promise<{ data: T; ticket: number }> {
+  if (!options.force) {
+    const pending = inflight.get(key);
+    if (pending) return pending.promise as Promise<{ data: T; ticket: number }>;
+  }
+
+  const ticket = ++seq;
+  const promise = (async () => {
     try {
       const data = await fetcher();
-      cache.set(key, data);
-      return data;
+      // 自分より新しいリクエストが書き込み済みなら、古い応答で上書きしない
+      if ((lastWrittenTicket.get(key) ?? 0) < ticket) {
+        cache.set(key, data);
+        lastWrittenTicket.set(key, ticket);
+      }
+      return { data, ticket };
     } finally {
-      inflight.delete(key);
+      if (inflight.get(key)?.ticket === ticket) inflight.delete(key);
     }
   })();
-  inflight.set(key, p);
-  return p;
+  inflight.set(key, { promise, ticket });
+  return promise;
 }
 
 /** テスト用: モジュールスコープのキャッシュと進行中リクエストを破棄する */
 export function clearClientCache() {
   cache.clear();
   inflight.clear();
+  lastWrittenTicket.clear();
 }

--- a/lib/db.test.ts
+++ b/lib/db.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// PrismaClient の実接続を避け、インスタンスの同一性だけを検証する
+vi.mock("@prisma/client", () => ({
+  PrismaClient: class FakePrismaClient {
+    id = Math.random();
+  },
+}));
+vi.mock("@prisma/adapter-neon", () => ({
+  PrismaNeon: class FakePrismaNeon {},
+}));
+
+import { getDb } from "./db";
+
+// OpenNext が本番 Worker で定義するのと同じグローバルシンボル
+const CTX = Symbol.for("__cloudflare-context__");
+const originalNavigator = (globalThis as { navigator?: unknown }).navigator;
+
+function setStore(store: object | undefined) {
+  Object.defineProperty(globalThis, CTX, {
+    configurable: true,
+    get: () => store,
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, CTX);
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  });
+});
+
+describe("getDb", () => {
+  it("同一リクエスト（同一 store）内では同じクライアントを返す", () => {
+    setStore({ env: {}, ctx: {}, cf: {} });
+
+    const a = getDb();
+    const b = getDb();
+
+    expect(a).toBe(b);
+  });
+
+  it("リクエスト（store）が変わればクライアントも別になる", () => {
+    setStore({ env: {}, ctx: {}, cf: {} });
+    const a = getDb();
+    setStore({ env: {}, ctx: {}, cf: {} });
+    const b = getDb();
+
+    expect(a).not.toBe(b);
+  });
+
+  it("ALS の外（Node 環境）ではプロセスワイド singleton を返す", () => {
+    setStore(undefined);
+
+    const a = getDb();
+    const b = getDb();
+
+    expect(a).toBe(b);
+  });
+
+  it("Workers 上で ALS の外に出た場合は共有せず都度生成する", () => {
+    // リクエスト跨ぎの接続共有は Workers では実行時エラーになるため、安全側に倒す
+    setStore(undefined);
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { userAgent: "Cloudflare-Workers" },
+    });
+
+    const a = getDb();
+    const b = getDb();
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,21 +1,79 @@
-import { cache } from "react";
 import { PrismaClient } from "@prisma/client";
 import { PrismaNeon } from "@prisma/adapter-neon";
 
-// Cloudflare Workers ではリクエストをまたいだ DB 接続の再利用が禁止されているため、
-// 従来のグローバル singleton（globalThis.prisma）は使えない。
-// 「リクエストごとに」クライアントを生成し、React の cache() で同一リクエスト内だけ
-// memoize する（OpenNext の DB howto 準拠）。Neon ドライバアダプタ経由で接続する。
-export const getDb = cache((): PrismaClient => {
+// Cloudflare Workers ではリクエストをまたいだ DB 接続の再利用が禁止されている
+// （"Cannot perform I/O on behalf of a different request"）ため、従来のグローバル
+// singleton（globalThis.prisma）は使えない。
+//
+// 旧実装は React の cache() で「リクエスト内 memoize」を狙っていたが、cache() は
+// RSC のレンダリング中しか効かず、API ルートハンドラでは毎アクセスが素通しになる。
+// その結果、DB 文を1つ実行するたびに新しい PrismaClient + Neon 接続（TLS +
+// WebSocket + 認証のハンドシェイク）が張られ、実測で1文あたり 250〜500ms の
+// オーバーヘッドが乗っていた（例: 予約 POST は認証2クエリ＋トランザクションで
+// 直列3接続）。
+//
+// 現実装は OpenNext の per-request コンテキストに乗る:
+// 本番 Worker はリクエストごとに AsyncLocalStorage へ新しい store（{env, ctx, cf}）を
+// 積み、globalThis[Symbol.for("__cloudflare-context__")] の getter がそれを返す
+// （.open-next/cloudflare/init.js。RSC・ルートハンドラ・waitUntil 内すべてで有効）。
+// この store オブジェクトを WeakMap のキーにすると「1リクエスト=1クライアント」に
+// 正確に集約でき、リクエスト終了後は store ごと GC される。
+//
+// ※ @opennextjs/cloudflare の getCloudflareContext() と同じ入口だが、db.ts は
+//   middleware（edge ビルド）にもバンドルされるため、パッケージを import せず
+//   シンボルを直接読む（シンボル名は OpenNext が worker テンプレートと同期を保証）。
+const CLOUDFLARE_CONTEXT_SYMBOL = Symbol.for("__cloudflare-context__");
+
+function getRequestStore(): object | undefined {
+  const store = (globalThis as Record<symbol, unknown>)[CLOUDFLARE_CONTEXT_SYMBOL];
+  return typeof store === "object" && store !== null ? store : undefined;
+}
+
+const perRequestClients = new WeakMap<object, PrismaClient>();
+
+// Node 環境（next dev / vitest / next build）用のプロセスワイド singleton。
+// Workers の per-request 制約は workerd 上だけの話なので、Node では共有してよい。
+let nodeSingleton: PrismaClient | undefined;
+
+function createClient(): PrismaClient {
   const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL });
   return new PrismaClient({ adapter });
-});
+}
+
+function isCloudflareWorkers(): boolean {
+  // workerd は navigator.userAgent を "Cloudflare-Workers" に固定している
+  return (
+    (globalThis as { navigator?: { userAgent?: string } }).navigator?.userAgent ===
+    "Cloudflare-Workers"
+  );
+}
+
+export function getDb(): PrismaClient {
+  // 本番 (Workers): リクエストごとの ALS store をキーに1接続へ集約する
+  const store = getRequestStore();
+  if (store) {
+    let client = perRequestClients.get(store);
+    if (!client) {
+      client = createClient();
+      perRequestClients.set(store, client);
+    }
+    return client;
+  }
+  if (isCloudflareWorkers()) {
+    // Workers 上で ALS の外に出た想定外のケース。リクエスト跨ぎの共有は禁止されて
+    // いるため、遅くても安全な「都度生成」に倒す（旧実装と同じ挙動）。
+    return createClient();
+  }
+  // ALS の外 = Node 環境（next dev / vitest / build）
+  nodeSingleton ??= createClient();
+  return nodeSingleton;
+}
 
 // 後方互換レイヤ:
 // 既存コードは `import { db } from "@/lib/db"` で `db.user.findMany()` のように使う。
-// それらを一括改修せずに済むよう、プロパティアクセスのたびに getDb()（リクエスト内 memoize 済み）
-// へ委譲する Proxy を `db` として公開する。モジュールロード時には接続を張らないため、
-// Workers の per-request 制約を満たしつつ呼び出し側は無改修で動く。
+// それらを一括改修せずに済むよう、プロパティアクセスのたびに getDb()（リクエスト内
+// 共有済み）へ委譲する Proxy を `db` として公開する。モジュールロード時には接続を
+// 張らないため、Workers の per-request 制約を満たしつつ呼び出し側は無改修で動く。
 export const db: PrismaClient = new Proxy({} as PrismaClient, {
   get(_target, prop) {
     const client = getDb();

--- a/lib/image-compress.test.ts
+++ b/lib/image-compress.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { compressImage } from "./image-compress";
+
+// jsdom には createImageBitmap / canvas が無いため、ここでは fail-open の
+// スキップ経路（原本をそのまま返す契約）を固定する。実際の縮小はブラウザでのみ動く。
+describe("compressImage", () => {
+  it("画像以外のファイルはそのまま返す", async () => {
+    const file = new File(["abc"], "list.csv", { type: "text/csv" });
+    expect(await compressImage(file)).toBe(file);
+  });
+
+  it("GIF / SVG は変換で壊れるためそのまま返す", async () => {
+    const gif = new File([new Uint8Array(400 * 1024)], "a.gif", { type: "image/gif" });
+    const svg = new File([new Uint8Array(400 * 1024)], "a.svg", { type: "image/svg+xml" });
+    expect(await compressImage(gif)).toBe(gif);
+    expect(await compressImage(svg)).toBe(svg);
+  });
+
+  it("しきい値以下の軽い画像はそのまま返す", async () => {
+    const small = new File([new Uint8Array(100 * 1024)], "small.png", { type: "image/png" });
+    expect(await compressImage(small)).toBe(small);
+  });
+
+  it("createImageBitmap が無い環境では原本を返す（fail-open）", async () => {
+    // jsdom には createImageBitmap が無い。この経路でアップロードが止まらないことが契約
+    const big = new File([new Uint8Array(4 * 1024 * 1024)], "photo.png", { type: "image/png" });
+    expect(await compressImage(big)).toBe(big);
+  });
+});

--- a/lib/image-compress.ts
+++ b/lib/image-compress.ts
@@ -1,0 +1,65 @@
+// アップロード前にブラウザ側で画像を縮小・再エンコードする。
+// スマホ写真（3〜8MBが普通）を無加工で R2 に置くと、全部員が 52px のサムネイル表示の
+// ために原寸をダウンロードすることになる。一覧表示には長辺 1600px あれば十分。
+//
+// fail-open 設計: 変換できない環境・入力では原本をそのまま返し、アップロード自体は
+// 止めない（圧縮は最適化であって前提条件ではない）。
+
+const RECOMPRESS_THRESHOLD_BYTES = 300 * 1024; // これ以下は十分軽いのでそのまま
+const MAX_EDGE_PX = 1600;
+const JPEG_QUALITY = 0.85;
+
+export async function compressImage(file: File): Promise<File> {
+  try {
+    if (!file.type.startsWith("image/")) return file;
+    // GIF はアニメーション、SVG はベクタ情報が失われるため対象外
+    if (file.type === "image/gif" || file.type === "image/svg+xml") return file;
+    if (file.size <= RECOMPRESS_THRESHOLD_BYTES) return file;
+    if (typeof createImageBitmap !== "function") return file;
+
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(1, MAX_EDGE_PX / Math.max(bitmap.width, bitmap.height));
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+
+    const blob = await drawToJpeg(bitmap, width, height);
+    bitmap.close();
+
+    // 再エンコードで逆に大きくなった場合（既に高圧縮の画像など）は原本を使う
+    if (!blob || blob.size >= file.size) return file;
+
+    const name = file.name.replace(/\.[^.]+$/, "") + ".jpg";
+    return new File([blob], name, { type: "image/jpeg" });
+  } catch {
+    return file;
+  }
+}
+
+async function drawToJpeg(
+  bitmap: ImageBitmap,
+  width: number,
+  height: number
+): Promise<Blob | null> {
+  const draw = (ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D) => {
+    // JPEG は透過を持てず、そのままだと透過部分が黒くなるため白で敷く
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, width, height);
+    ctx.drawImage(bitmap, 0, 0, width, height);
+  };
+
+  if (typeof OffscreenCanvas !== "undefined") {
+    const canvas = new OffscreenCanvas(width, height);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    draw(ctx);
+    return canvas.convertToBlob({ type: "image/jpeg", quality: JPEG_QUALITY });
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  draw(ctx);
+  return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", JPEG_QUALITY));
+}

--- a/lib/jst-date.ts
+++ b/lib/jst-date.ts
@@ -1,0 +1,19 @@
+// JST（Asia/Tokyo）の「今日」を扱う小さなヘルパー。
+// 以前は moment-timezone を使っていたが、用途がこの1パターンだけなのに
+// 全タイムゾーンDB（約0.7MB）がサーバーバンドルに同梱されコールドスタートを
+// 押し上げていたため、標準の Intl に置き換えた。
+
+/** JST での今日の日付を YYYY-MM-DD で返す（en-CA ロケールは YYYY-MM-DD 形式）。 */
+export function todayJstDateString(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+}
+
+/** JST での今日を UTC 深夜0時の Date として返す（予約日付カラムとの比較用）。 */
+export function todayJstAsUtcMidnight(): Date {
+  return new Date(`${todayJstDateString()}T00:00:00Z`);
+}

--- a/lib/jwt-refresh.test.ts
+++ b/lib/jwt-refresh.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getUserByIdMock, getAccountByUserIdMock } = vi.hoisted(() => ({
+  getUserByIdMock: vi.fn(),
+  getAccountByUserIdMock: vi.fn(),
+}));
+
+vi.mock("@/data/user", () => ({ getUserById: getUserByIdMock }));
+vi.mock("@/data/account", () => ({ getAccountByUserId: getAccountByUserIdMock }));
+
+import { ROLE_REFRESH_INTERVAL_MS, refreshJwtToken } from "./jwt-refresh";
+
+const dbUser = {
+  id: "u1",
+  name: "Taro",
+  email: "taro@example.com",
+  role: "ADMIN",
+  isTwoFactorEnabled: false,
+};
+
+beforeEach(() => {
+  getUserByIdMock.mockReset();
+  getUserByIdMock.mockResolvedValue(dbUser);
+  getAccountByUserIdMock.mockReset();
+  getAccountByUserIdMock.mockResolvedValue(null);
+});
+
+describe("refreshJwtToken", () => {
+  it("sub が無い token はそのまま返し、DB に触れない", async () => {
+    const token = {};
+    const out = await refreshJwtToken({ token });
+    expect(out).toBe(token);
+    expect(getUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("サインイン直後（user あり）は DB を照会して token に反映する", async () => {
+    const token: Record<string, unknown> = { sub: "u1" };
+    const out = await refreshJwtToken({ token, user: { id: "u1" } });
+
+    expect(getUserByIdMock).toHaveBeenCalledWith("u1");
+    expect(out.role).toBe("ADMIN");
+    expect(out.name).toBe("Taro");
+    expect(out.isOAuth).toBe(false);
+    expect(typeof out.refreshedAt).toBe("number");
+  });
+
+  it("refreshedAt が新しい通常リクエストでは DB 照会しない（全リクエスト2クエリの回帰防止）", async () => {
+    const token = { sub: "u1", role: "USER", refreshedAt: Date.now() };
+    const out = await refreshJwtToken({ token });
+
+    expect(getUserByIdMock).not.toHaveBeenCalled();
+    expect(getAccountByUserIdMock).not.toHaveBeenCalled();
+    expect(out.role).toBe("USER");
+  });
+
+  it("refreshedAt が閾値を超えていたら再照会する（DB での role 変更が最大15分で反映される）", async () => {
+    const token = {
+      sub: "u1",
+      role: "USER",
+      refreshedAt: Date.now() - ROLE_REFRESH_INTERVAL_MS - 1000,
+    };
+    const out = await refreshJwtToken({ token });
+
+    expect(getUserByIdMock).toHaveBeenCalledWith("u1");
+    expect(out.role).toBe("ADMIN");
+  });
+
+  it("refreshedAt を持たない既存セッションの token は初回に再照会する（後方互換）", async () => {
+    const token = { sub: "u1", role: "USER" };
+    const out = await refreshJwtToken({ token });
+
+    expect(getUserByIdMock).toHaveBeenCalledWith("u1");
+    expect(out.role).toBe("ADMIN");
+  });
+
+  it("trigger=update は経過時間に関係なく再照会する（update({}) による即時反映の経路）", async () => {
+    const token = { sub: "u1", name: "旧名", refreshedAt: Date.now() };
+    const out = await refreshJwtToken({ token, trigger: "update" });
+
+    expect(getUserByIdMock).toHaveBeenCalledWith("u1");
+    expect(out.name).toBe("Taro");
+  });
+
+  it("ユーザーが DB に存在しなければ token を書き換えずに返す", async () => {
+    getUserByIdMock.mockResolvedValue(null);
+    const token = { sub: "gone", role: "USER" };
+    const out = await refreshJwtToken({ token, trigger: "update" });
+
+    expect(out.role).toBe("USER");
+    expect(out.refreshedAt).toBeUndefined();
+  });
+
+  it("OAuth アカウントがあれば isOAuth=true", async () => {
+    getAccountByUserIdMock.mockResolvedValue({ provider: "google" });
+    const out = await refreshJwtToken({ token: { sub: "u1" }, user: { id: "u1" } });
+    expect(out.isOAuth).toBe(true);
+  });
+});

--- a/lib/jwt-refresh.ts
+++ b/lib/jwt-refresh.ts
@@ -1,0 +1,44 @@
+import { getUserById } from "@/data/user";
+import { getAccountByUserId } from "@/data/account";
+
+// jwt コールバック本体。auth.ts から分離してあるのは、NextAuth の初期化なしに
+// 単体テストできるようにするため。
+//
+// DB 照会の方針:
+// - サインイン直後（user あり）と useSession().update() 実行時（trigger === "update"）は必ず照会
+//   ※ update() は「引数なし」だと GET になり trigger が立たない。呼び出し側は update({}) を使うこと。
+// - それ以外は、前回照会から ROLE_REFRESH_INTERVAL_MS 経過したときだけ照会する。
+//   毎リクエスト user/account の2クエリを払う従来実装は全ページ・全APIの恒常的な遅延源だった。
+//   一方で照会を完全にやめると、DB 側での role 変更・剥奪が最長30日（セッション寿命）反映されない。
+//   時間ベースの再照会で「通常は DB フリー、権限変更の反映遅延は最大15分」に落とし込む。
+export const ROLE_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
+interface JwtParams {
+  token: Record<string, unknown> & { sub?: string };
+  user?: unknown;
+  trigger?: "signIn" | "signUp" | "update";
+}
+
+export async function refreshJwtToken({ token, user, trigger }: JwtParams) {
+  if (!token.sub) return token;
+
+  const isStale =
+    typeof token.refreshedAt !== "number" ||
+    Date.now() - token.refreshedAt > ROLE_REFRESH_INTERVAL_MS;
+
+  if (!user && trigger !== "update" && !isStale) return token;
+
+  const existingUser = await getUserById(token.sub);
+  if (!existingUser) return token;
+
+  const existingAccount = await getAccountByUserId(existingUser.id);
+
+  token.isOAuth = !!existingAccount;
+  token.name = existingUser.name;
+  token.email = existingUser.email;
+  token.role = existingUser.role;
+  token.isTwoFactorEnabled = existingUser.isTwoFactorEnabled;
+  token.refreshedAt = Date.now();
+
+  return token;
+}

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -134,9 +134,14 @@ export async function notifyReservationCreated(reserve: ReserveLike): Promise<vo
 }
 
 // 管理者が他人の予約を取り消したことを、予約の持ち主へ知らせる。
-export async function notifyReservationCancelled(reserve: ReserveLike): Promise<void> {
+// listNameOverride: 機材削除に伴う取り消しでは通知時点で List 行が消えているため、
+// 削除前に控えた機材名を呼び出し側から渡す。
+export async function notifyReservationCancelled(
+  reserve: ReserveLike,
+  listNameOverride?: string
+): Promise<void> {
   if (!reserve.user_id) return;
-  const name = await listName(reserve.list_id);
+  const name = listNameOverride ?? (await listName(reserve.list_id));
   const period = `${formatReserveDate(reserve.start)} 〜 ${formatReserveDate(reserve.end)}`;
   await notifyUser(reserve.user_id, "reservationEvents", {
     subject: `予約が取り消されました（${name}）`,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,19 @@ const withSerwist = withSerwistInit({
   swDest: 'public/sw.js',
   // ↓開発中にservice workerを無効にする場合は以下のコメントを外す
   // disable: process.env.NODE_ENV === "development",
+
+  // precache は「アプリの起動に必要な最小限」に絞る。
+  // 以前はデフォルト（public/ 全部 + 全ビルド資産）で約19MBを全端末に先読みさせていた:
+  // README用画像 5.8MB / manifest用スクリーンショット 5.8MB / フォント全サブセット約5MB。
+  // フォントは defaultCache の static-font-assets（実際に使う数個だけ）で十分。
+  globPublicPatterns: [
+    'manifest.json',
+    'favicon.ico',
+    'ABS-EMS*.{png,webp}',
+    'logicode.jpeg',
+  ],
+  // 先頭2つは serwist のデフォルト exclude（上書きするため明示的に残す）
+  exclude: [/\.map$/, /^manifest.*\.js$/, /\.woff2$/],
 });
 
 const nextConfig = withSerwist({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,9 @@ const withSerwist = withSerwistInit({
   globPublicPatterns: [
     'manifest.json',
     'favicon.ico',
-    'ABS-EMS*.{png,webp}',
+    'ABS-EMS512_maskable.png',
+    'ABS-EMS512_rounded.png',
+    'ABS-EMS-Icon.webp',
     'logicode.jpeg',
   ],
   // 先頭2つは serwist のデフォルト exclude（上書きするため明示的に残す）

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@radix-ui/react-switch": "^1.3.2",
         "@radix-ui/react-tabs": "^1.1.16",
         "@serwist/next": "^9.5.11",
-        "axios": "^1.7.7",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -6640,17 +6639,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -6965,18 +6953,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -9023,26 +8999,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -9548,18 +9504,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -11775,15 +11719,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
-        "moment-timezone": "^0.5.45",
         "next": "^15.5.16",
         "next-auth": "^5.0.0-beta.17",
         "next-themes": "^0.4.6",
@@ -10765,25 +10764,6 @@
       "license": "MIT",
       "dependencies": {
         "obliterator": "^1.6.1"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.46",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "moment-timezone": "^0.5.45",
     "next": "^15.5.16",
     "next-auth": "^5.0.0-beta.17",
     "next-themes": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@radix-ui/react-switch": "^1.3.2",
     "@radix-ui/react-tabs": "^1.1.16",
     "@serwist/next": "^9.5.11",
-    "axios": "^1.7.7",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,14 @@
   ],
   "exclude": [
     "node_modules",
-    "worker-configuration.d.ts"
+    "worker-configuration.d.ts",
+    // 生成物と、その生成物を import する worker.ts（wrangler が別途コンパイルする入口）。
+    // worker.ts を含めると .open-next/worker.js の module 解決を経由して 6MB 超の
+    // バンドル済み handler.mjs まで型検査対象に入り、tsc / next build が
+    // 「Maximum call stack size exceeded」で落ちる（.open-next が存在するときだけ再現）。
+    ".open-next",
+    ".wrangler",
+    "public/sw.js",
+    "worker.ts"
   ]
 }

--- a/worker.ts
+++ b/worker.ts
@@ -7,6 +7,12 @@
  * .open-next/worker.js はビルド時（opennextjs-cloudflare build）に生成されるので、
  * 型チェック時点では存在しないことがある。生成物の有無で挙動が変わらないよう
  * @ts-ignore で握る（@ts-expect-error は生成物が残っていると「未使用」で失敗する）。
+ *
+ * 注意: このファイルは tsconfig.json の exclude に入れてある。@ts-ignore はエラーを
+ * 握るだけで module 解決自体は行われるため、.open-next が残っていると 6MB 超の
+ * バンドル済み handler.mjs まで型検査対象に入り、tsc / next build がスタック
+ * オーバーフローで落ちる。このファイル自体は wrangler(esbuild) がデプロイ時に
+ * 別途コンパイルする。
  */
 // @ts-ignore .open-next/worker.js はビルド時に生成される
 import worker from './.open-next/worker.js';


### PR DESCRIPTION
## 概要

ユーザー視点の UI/パフォーマンスレビュー（7観点の並列レビュー＋指摘ごとの敵対的検証で60件を確認）に対する3ラウンドの対応をリリースします。各ラウンドとも差分の多エージェントレビュー→修正→テストを経て develop へマージ済みです。

詳細レポート: https://claude.ai/code/artifact/1e82fbe4-bb95-4653-b9f5-3faee79422ed

## 主な変更

### 体感パフォーマンス（遅さの根本原因3つを解消）
- **認証の税金を撤廃**: jwt コールバックの DB 照会を「サインイン時・update({})時・15分経過時のみ」に限定（従来は全ページ・全APIで毎回 user/account の2クエリ）。`lib/jwt-refresh.ts` に分離＋単体テスト
- **DB接続をリクエストスコープ化**: API ルートで DB 文ごとに新規 Neon 接続（実測250〜500ms/文）が張られていたのを、OpenNext の per-request store をキーに「1リクエスト=1接続」へ集約（`lib/db.ts`）
- **クライアントキャッシュ導入**: stale-while-revalidate の共通フック（`hooks/use-cached-endpoint.ts`）。タブ切り替えのたびに全再取得してスケルトンに戻る問題を解消。変更直後の refetch は進行中リクエストに相乗りしない（force＋世代チケット）、エラー応答は非キャッシュ
- Service Worker の precache を約19MB→2.3MBに削減（README画像・スクリーンショット・フォント全部入りを除外）
- moment-timezone / axios を削除（Intl・fetch へ置換）
- 機材画像: アップロード前のブラウザ縮小（長辺1600px）＋ R2 に immutable Cache-Control
- `/api/reserves` に `?from/?to` 期間フィルタ（予約ウィザードは今日以降のみ取得）

### 予約フロー
- 複数機材予約の部分成功を機材名つきで可視化し、成功分をカートから自動除去（「全部失敗」に見えて予約し直す二重予約の温床を解消）
- 確定ボタンの二度押し窓を解消、409以外は API の具体的エラーを表示
- 機材名検索＋「空きのみ」絞り込み、競合の「ほかN件」表示
- タブ復帰・Step2遷移時に空き状況を再取得（古い「空いています」の解消）
- カテゴリ未設定・削除済みカテゴリの機材を「未分類」グループとして表示（機材が予約画面から消える問題）

### カレンダー
- 部員色の衝突回避（16色パレット＋表示月の部員を優先する一意割り当て。バー・チップ・詳細カードで共有）
- モバイルでバータップ時に詳細カードへ自動スクロール（「反応がない」ように見えた）
- 機材ガントに週送り・「今日」・期間ラベル・M/D表記（固定14日窓の解消）
- 通信失敗時は無限スケルトンではなく再試行ボタン付きエラー表示
- 月表示に「今日」ボタン、バーのタップ領域拡大

### マイページ・設定・認証
- 未返却のまま期限超過した予約を最上部「要返却」セクション＋警告バナーに（「終了した予約」の山に埋もれていた）
- 返却に確認ダイアログ（誤タップで即返却済みになると本人は戻せない）
- 終了した予約は新しい順・直近5件＋「すべて表示」
- ログイン失敗時の form.reset() 廃止（メール欄全消去・2FA詰みの解消）、英語エラーの日本語化、パスワード要件の事前提示、認証カードの固定幅解消
- プロフィール保存後にセッションへ即時反映、設定の戻るは履歴ベース

### 管理画面
- 機材削除: 貸出中は409でブロック／関連予約をトランザクションで連鎖削除（孤児予約「#42」の解消）／**予約した部員へ取り消し通知を送信**／ダイアログに今後の予約件数を警告（取得中は確定不可）
- 画像アップロード失敗の検知（403/500でも「登録完了」と出ていた）、カテゴリ未選択登録の防止
- 編集画面のロード/エラー状態、写真のドラッグ&ドロップ実装、カテゴリの色編集・重複名チェック

### 基盤
- `app/error.tsx`・`loading.tsx` 追加（エラー時の英語画面・タブ無反応の解消）
- tsconfig の生成物 exclude（`.open-next` 経由の型検査スタックオーバーフローで `next build` が落ちることがあった）

## 検証

- vitest **405件全通過**（このリリースで約60件追加）、tsc 0エラー、`next build` 成功
- 各ラウンドの差分に対する多エージェント敵対的レビュー（計21件の退行・不備を検出し修正済み）
- dev サーバー＋Chrome での実機スモークテスト（カレンダー・ガント・予約検索・マイ予約・タブ切替の即時表示・コンソールエラーなし）

## デプロイ時の注意

- **DBマイグレーションなし**（スキーマ変更なし）
- 既存セッションはそのまま有効（jwt に refreshedAt クレームが増えるが、無い場合は初回リクエストで再照会されて付与される）
- 運用側は適用済み: R2 既存23画像への Cache-Control 遡及付与、images ドメインの Cache Rule（エッジキャッシュ HIT 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQKp4tERqX2DTEr7daJSnx