### PR TITLE
リリース: カレンダー高速化・テーマカラー/アイコン設定・認証画面刷新

### DIFF
--- a/app/(protected)/_components/UserMenu.tsx
+++ b/app/(protected)/_components/UserMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
@@ -103,9 +104,21 @@ export const UserMenu = () => {
       <DropdownMenu>
         <DropdownMenuTrigger
           aria-label="ユーザーメニュー"
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-brand text-[13px] font-bold text-white outline-none ring-offset-navy focus-visible:ring-2 focus-visible:ring-white/60"
+          className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-brand text-[13px] font-bold text-white outline-none ring-offset-navy focus-visible:ring-2 focus-visible:ring-white/60"
+          // アイコン未設定ならテーマカラー（設定ページで選択）をイニシャルの背景にする
+          style={!user?.image && user?.color ? { background: user.color } : undefined}
         >
-          {initialOf(user?.name)}
+          {user?.image ? (
+            <Image
+              src={user.image}
+              alt=""
+              width={32}
+              height={32}
+              className="h-8 w-8 rounded-full object-cover"
+            />
+          ) : (
+            initialOf(user?.name)
+          )}
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-52" align="end">
           <DropdownMenuLabel className="truncate">

--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import {
   useCalendarData,
+  prefetchCalendarWindow,
   type CalendarEvent,
 } from "@/app/(protected)/ems/common/hooks/use-calendar-data";
 import {
@@ -30,7 +31,6 @@ function eventInterval(ev: CalendarEvent) {
 }
 
 export function CalendarBoard({ initialView = "month" }: { initialView?: View }) {
-  const { allEvents, isFetching, isError, refetch } = useCalendarData();
   const todayIdx = todayJstDayIndex();
   // PC では行高を上げてカレンダーを画面の高さに合わせて大きく見せる
   const isDesktop = useIsDesktop();
@@ -58,10 +58,42 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
     [viewYear, viewMonth0]
   );
 
-  // 絞り込みチップは「表示中の月グリッドに予約が掛かる部員」だけに絞る
-  // （全期間の部員を並べるとチップが縦に膨らむうえ、選んでも何も起きない）。
   const gridStartIdx = matrix.weeks[0][0].dayIndex;
   const gridEndIdx = matrix.weeks[matrix.weeks.length - 1][6].dayIndex;
+
+  // ガント: 既定は「今日の3日前から14日窓」。1週間単位で前後に送れる
+  //（固定窓だと来週末より先の空きが確認できず、月表示への切替に気づかないと詰む）。
+  const [ganttWeekOffset, setGanttWeekOffset] = useState(0);
+  const ganttDayCount = 14;
+  const ganttWindowStart = todayIdx - 3 + ganttWeekOffset * 7;
+  const ganttWindowEnd = ganttWindowStart + ganttDayCount - 1;
+
+  // データは「いま画面に必要な窓」だけ取得する（月表示=月グリッド、ガント=14日窓）。
+  // 窓の外の予約はサーバー側で絞られるため、履歴が増えても取得・描画コストは一定。
+  const { allEvents, isFetching, isError, isWindowLoading, isWindowError, refetch } =
+    useCalendarData(
+      view === "month" ? gridStartIdx : ganttWindowStart,
+      view === "month" ? gridEndIdx : ganttWindowEnd
+    );
+
+  // 月送りの待ちを実質ゼロにするため、表示が落ち着いたら前後の月グリッドを裏で温める
+  useEffect(() => {
+    if (view !== "month" || isFetching) return;
+    const prevMonth = buildMonthMatrix(
+      viewMonth0 === 0 ? viewYear - 1 : viewYear,
+      viewMonth0 === 0 ? 11 : viewMonth0 - 1
+    );
+    const nextMonth = buildMonthMatrix(
+      viewMonth0 === 11 ? viewYear + 1 : viewYear,
+      viewMonth0 === 11 ? 0 : viewMonth0 + 1
+    );
+    for (const m of [prevMonth, nextMonth]) {
+      prefetchCalendarWindow(m.weeks[0][0].dayIndex, m.weeks[m.weeks.length - 1][6].dayIndex);
+    }
+  }, [view, viewYear, viewMonth0, isFetching]);
+
+  // 絞り込みチップは「表示中の月グリッドに予約が掛かる部員」だけに絞る
+  // （全期間の部員を並べるとチップが縦に膨らむうえ、選んでも何も起きない）。
   const members = useMemo(() => {
     const set = new Set<string>();
     allEvents.forEach((e) => {
@@ -115,12 +147,6 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
     [barEvents, matrix, isDesktop]
   );
 
-  // ガント: 既定は「今日の3日前から14日窓」。1週間単位で前後に送れる
-  //（固定窓だと来週末より先の空きが確認できず、月表示への切替に気づかないと詰む）。
-  const [ganttWeekOffset, setGanttWeekOffset] = useState(0);
-  const ganttDayCount = 14;
-  const ganttWindowStart = todayIdx - 3 + ganttWeekOffset * 7;
-  const ganttWindowEnd = ganttWindowStart + ganttDayCount - 1;
   const ganttRows = useMemo<GanttRow<CalendarEvent>[]>(() => {
     const byEquip = new Map<string, GanttRow<CalendarEvent>>();
     allEvents.forEach((ev) => {
@@ -299,11 +325,32 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         )}
       </div>
 
+      {/* 窓の切り替え（月送り・週送り）に失敗しても、表示中のデータは残っているため
+          全画面エラーにはせずインラインで再試行を出す */}
+      {isWindowError && (
+        <div className="mb-3 flex items-center justify-between rounded-xl border border-[#FEE4E2] bg-[#FFF5F4] py-2 pl-3.5 pr-2 text-[12.5px] font-bold text-danger">
+          この期間の予約を読み込めませんでした
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="ml-3 h-8 flex-none rounded-lg px-2.5 text-xs font-bold text-danger hover:bg-danger/10"
+          >
+            再試行
+          </button>
+        </div>
+      )}
+
       {view === "month" ? (
         // grid-cols-1（minmax(0,1fr)）を明示しないと、モバイルでトラックが
         // コンテンツ幅に広がり画面からはみ出す
         <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="rounded-2xl bg-white p-4 shadow-sm">
+          <div
+            className={cn(
+              "rounded-2xl bg-white p-4 shadow-sm transition-opacity",
+              // 窓の取得中は前の窓を出したまま淡くする（前後月はプリフェッチ済みのため稀）
+              isWindowLoading && "opacity-60"
+            )}
+          >
             <MemberChips
               members={members}
               value={memberFilter}
@@ -334,7 +381,12 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
           </div>
         </div>
       ) : (
-        <div className="rounded-2xl bg-white p-3 shadow-sm">
+        <div
+          className={cn(
+            "rounded-2xl bg-white p-3 shadow-sm transition-opacity",
+            isWindowLoading && "opacity-60"
+          )}
+        >
           {ganttRows.length === 0 ? (
             <p className="py-10 text-center text-[12.5px] text-ink-faint">
               この期間に貸出中の機材はありません

--- a/app/(protected)/ems/common/_components/CalendarBoard.tsx
+++ b/app/(protected)/ems/common/_components/CalendarBoard.tsx
@@ -70,8 +70,16 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
 
   // データは「いま画面に必要な窓」だけ取得する（月表示=月グリッド、ガント=14日窓）。
   // 窓の外の予約はサーバー側で絞られるため、履歴が増えても取得・描画コストは一定。
-  const { allEvents, isFetching, isError, isWindowLoading, isWindowError, refetch } =
-    useCalendarData(
+  const {
+    allEvents,
+    memberColors,
+    memberImages,
+    isFetching,
+    isError,
+    isWindowLoading,
+    isWindowError,
+    refetch,
+  } = useCalendarData(
       view === "month" ? gridStartIdx : ganttWindowStart,
       view === "month" ? gridEndIdx : ganttWindowEnd
     );
@@ -110,13 +118,20 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
   }, [members, memberFilter]);
 
   // 「色＝人」の前提を守るため、素のハッシュ色（少人数でも高確率で衝突する）ではなく
-  // 重複しない割り当てを使う。表示中の月の部員（members）を優先して割り当てることで、
+  // 重複しない割り当てを使う。本人が設定ページで選んだ色（memberColors）を最優先し、
+  // 未選択の部員は表示中の月の部員（members）を優先して割り当てることで、
   // 履歴上の部員が16人を超えても「いま見えている月」の中では一意性が守られる。
   // チップ・詳細カードも同じ割り当てを共有する。
   const memberColorOf = useMemo(() => {
-    const map = memberColorMap(allEvents.map((e) => e.name), members);
+    const map = memberColorMap(allEvents.map((e) => e.name), members, memberColors);
     return (name: string | null | undefined) => (name && map.get(name)) || "#667085";
-  }, [allEvents, members]);
+  }, [allEvents, members, memberColors]);
+
+  // 本人が設定したアイコン画像（チップ・詳細カード・ガントのバーで使う）
+  const memberImageOf = useMemo(
+    () => (name: string | null | undefined) => (name ? memberImages.get(name) : undefined),
+    [memberImages]
+  );
 
   const barEvents = useMemo<CalendarBarEvent<CalendarEvent>[]>(
     () =>
@@ -168,12 +183,13 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
         endIdx,
         color: memberColorOf(ev.name),
         initial: memberInitial(ev.name),
+        image: memberImageOf(ev.name),
         label: `〜${formatRange(endIdx, endIdx)}`,
         data: ev,
       });
     });
     return [...byEquip.values()];
-  }, [allEvents, ganttWindowStart, ganttWindowEnd, memberColorOf]);
+  }, [allEvents, ganttWindowStart, ganttWindowEnd, memberColorOf, memberImageOf]);
 
   const selectedEvent = allEvents.find((e) => e.id === selectedKey) ?? null;
   const detail = selectedEvent
@@ -356,6 +372,7 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
               value={memberFilter}
               onChange={setMemberFilter}
               colorOf={memberColorOf}
+              imageOf={memberImageOf}
               className="mb-3"
             />
             <MonthGrid<CalendarEvent>
@@ -370,7 +387,11 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
           </div>
           <div ref={detailRef} className="md:sticky md:top-24 md:self-start scroll-mt-20">
             {detail ? (
-              <EventDetailPopover detail={detail} color={memberColorOf(detail.who)} />
+              <EventDetailPopover
+                detail={detail}
+                color={memberColorOf(detail.who)}
+                image={memberImageOf(detail.who)}
+              />
             ) : (
               <div className="rounded-2xl border border-dashed border-line bg-white p-8 text-center text-[12.5px] text-ink-faint">
                 バーをタップすると
@@ -402,7 +423,11 @@ export function CalendarBoard({ initialView = "month" }: { initialView?: View })
           )}
           {detail && (
             <div ref={detailRef} className="mt-3 scroll-mt-20">
-              <EventDetailPopover detail={detail} color={memberColorOf(detail.who)} />
+              <EventDetailPopover
+                detail={detail}
+                color={memberColorOf(detail.who)}
+                image={memberImageOf(detail.who)}
+              />
             </div>
           )}
         </div>

--- a/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
@@ -1,7 +1,12 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useCalendarData } from "./use-calendar-data";
-import { clearClientCache } from "@/lib/client-cache";
+import {
+  useCalendarData,
+  calendarWindowUrl,
+  prefetchCalendarWindow,
+} from "./use-calendar-data";
+import { clearClientCache, getCachedData } from "@/lib/client-cache";
+import { toJstDayIndex } from "@/lib/calendar/date-grid";
 
 const fetchMock = vi.fn();
 const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -18,57 +23,58 @@ afterEach(() => {
   consoleLogSpy.mockClear();
 });
 
-const setupHappyPath = () => {
-  // /api/users（Prisma User の形: キーは id）
-  fetchMock.mockResolvedValueOnce({
-    ok: true, json: async () => [{ id: "u1", name: "Taro" }],
+// 1月の月グリッド相当の窓（"YYYY-MM-DD" は UTC 00:00 として解釈され、そのまま JST 暦日の day index になる）
+const JAN_FROM = toJstDayIndex("2026-01-01");
+const JAN_TO = toJstDayIndex("2026-01-31");
+const FEB_FROM = toJstDayIndex("2026-02-01");
+const FEB_TO = toJstDayIndex("2026-02-28");
+
+const payload = (overrides: Record<string, unknown> = {}) => ({
+  users: [{ id: "u1", name: "Taro" }],
+  lists: [{ id: 1, name: "Camera", tag_id: 10 }],
+  tags: [{ id: 10, name: "Audio", color: "#ff0000" }],
+  reserves: [
+    {
+      id: 100,
+      user_id: "u1",
+      start: "2026-01-01",
+      end: "2026-01-05",
+      list_id: 1,
+      isRenting: 0,
+    },
+  ],
+  ...overrides,
+});
+
+const okResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+describe("calendarWindowUrl", () => {
+  it("formats day indices as YYYY-MM-DD query params", () => {
+    expect(calendarWindowUrl(JAN_FROM, JAN_TO)).toBe(
+      "/api/calendar?from=2026-01-01&to=2026-01-31"
+    );
   });
-  // /api/lists
-  fetchMock.mockResolvedValueOnce({
-    ok: true, json: async () => [{ id: 1, name: "Camera", detail: "", image: "", usable: true, tag_id: 10 }],
-  });
-  // /api/tags
-  fetchMock.mockResolvedValueOnce({
-    ok: true, json: async () => [{ id: 10, name: "Audio", color: "#ff0000" }],
-  });
-  // /api/reserves
-  fetchMock.mockResolvedValueOnce({
-    ok: true, json: async () => [
-      {
-        id: 100,
-        user_id: "u1",
-        start: "2026-01-01",
-        end: "2026-01-05",
-        list_id: 1,
-        isRenting: 0,
-      },
-    ],
-  });
-};
+});
 
 describe("useCalendarData", () => {
   it("starts with empty events and isFetching=true", () => {
-    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
-    const { result } = renderHook(() => useCalendarData());
+    fetchMock.mockResolvedValue(okResponse(payload()));
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
     expect(result.current.allEvents).toEqual([]);
     expect(result.current.isFetching).toBe(true);
   });
 
-  it("calls the four API endpoints in order on mount", async () => {
-    setupHappyPath();
-    renderHook(() => useCalendarData());
+  it("calls the consolidated endpoint once with the window as from/to", async () => {
+    fetchMock.mockResolvedValue(okResponse(payload()));
+    renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
-
-    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/users");
-    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/lists");
-    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/tags");
-    expect(fetchMock).toHaveBeenNthCalledWith(4, "/api/reserves");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith("/api/calendar?from=2026-01-01&to=2026-01-31");
   });
 
   it("builds calendar events with mapped user name, equipment title, and tag color", async () => {
-    setupHappyPath();
-    const { result } = renderHook(() => useCalendarData());
+    fetchMock.mockResolvedValue(okResponse(payload()));
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
 
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
@@ -87,8 +93,8 @@ describe("useCalendarData", () => {
   });
 
   it("keeps end as the inclusive last day (no FullCalendar +1)", async () => {
-    setupHappyPath();
-    const { result } = renderHook(() => useCalendarData());
+    fetchMock.mockResolvedValue(okResponse(payload()));
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
 
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
@@ -98,48 +104,29 @@ describe("useCalendarData", () => {
   });
 
   it("falls back to default color when tag color is missing", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [{ id: "u1", name: "Taro" }] });
-    fetchMock.mockResolvedValueOnce({
-      ok: true, json: async () => [{ id: 1, name: "Camera", detail: "", image: "", usable: true, tag_id: 999 }],
-    });
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] }); // no tags
-    fetchMock.mockResolvedValueOnce({
-      ok: true, json: async () => [
-        {
-          id: 100,
-          user_id: "u1",
-          start: "2026-01-01",
-          end: "2026-01-05",
-          list_id: 1,
-          isRenting: 0,
-        },
-      ],
-    });
-
-    const { result } = renderHook(() => useCalendarData());
+    fetchMock.mockResolvedValue(
+      okResponse(payload({ lists: [{ id: 1, name: "Camera", tag_id: 999 }], tags: [] }))
+    );
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.allEvents[0].backgroundColor).toBe("#3788D8");
   });
 
   it("handles empty reserves response", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
-
-    const { result } = renderHook(() => useCalendarData());
+    fetchMock.mockResolvedValue(okResponse(payload({ reserves: [] })));
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.allEvents).toEqual([]);
   });
 
-  it("stops the skeleton and reports isError when a fetch rejects", async () => {
-    // 以前は fetch 失敗で isFetching が下りず無限スケルトンになっていた（回帰防止）
+  it("stops the skeleton and reports isError when the fetch rejects", async () => {
+    // fetch 失敗で isFetching が下りず無限スケルトンにならないこと（回帰防止）
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     fetchMock.mockRejectedValue(new Error("network down"));
 
-    const { result } = renderHook(() => useCalendarData());
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.isError).toBe(true);
@@ -147,13 +134,24 @@ describe("useCalendarData", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("treats an {error} body as a failure instead of caching it as empty data", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockResolvedValue(okResponse({ error: "認証されていません。" }));
+
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(getCachedData(calendarWindowUrl(JAN_FROM, JAN_TO))).toBeUndefined();
+    consoleErrorSpy.mockRestore();
+  });
+
   it("does not flip to isError when a revalidation fails after data has loaded", async () => {
     // 取得済みデータがあるのに再検証（タブ復帰・操作後）の失敗で全画面エラーへ
     // 乗っ取られないための契約（isError は「初回ロード失敗」専用）
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    setupHappyPath();
+    fetchMock.mockResolvedValueOnce(okResponse(payload()));
 
-    const { result } = renderHook(() => useCalendarData());
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
     await waitFor(() => expect(result.current.isFetching).toBe(false));
     expect(result.current.allEvents).toHaveLength(1);
 
@@ -170,18 +168,78 @@ describe("useCalendarData", () => {
   it("recovers after a successful refetch", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     fetchMock.mockRejectedValueOnce(new Error("network down"));
-    fetchMock.mockRejectedValueOnce(new Error("network down"));
-    fetchMock.mockRejectedValueOnce(new Error("network down"));
-    fetchMock.mockRejectedValueOnce(new Error("network down"));
 
-    const { result } = renderHook(() => useCalendarData());
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
-    await result.current.refetch();
+    fetchMock.mockResolvedValue(okResponse(payload({ reserves: [] })));
+    await act(async () => {
+      await result.current.refetch();
+    });
 
     await waitFor(() => expect(result.current.isError).toBe(false));
     expect(result.current.isFetching).toBe(false);
     consoleErrorSpy.mockRestore();
+  });
+
+  it("keeps showing the previous window while the next window is loading, then swaps", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(payload()));
+    const { result, rerender } = renderHook(
+      ({ from, to }: { from: number; to: number }) => useCalendarData(from, to),
+      { initialProps: { from: JAN_FROM, to: JAN_TO } }
+    );
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.allEvents).toHaveLength(1);
+
+    // 2月の応答を保留し、その間の表示を確認する
+    let resolveFeb!: (value: unknown) => void;
+    fetchMock.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveFeb = resolve))
+    );
+    rerender({ from: FEB_FROM, to: FEB_TO });
+
+    // スケルトンへ戻さず、前の窓（1月）のデータを出したまま裏で取得する
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.isWindowLoading).toBe(true);
+    expect(result.current.allEvents).toHaveLength(1);
+
+    await act(async () => {
+      resolveFeb(okResponse(payload({ reserves: [] })));
+    });
+    await waitFor(() => expect(result.current.isWindowLoading).toBe(false));
+    expect(result.current.allEvents).toEqual([]);
+  });
+
+  it("reports isWindowError (not full-screen isError) when only the new window fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchMock.mockResolvedValueOnce(okResponse(payload()));
+    const { result, rerender } = renderHook(
+      ({ from, to }: { from: number; to: number }) => useCalendarData(from, to),
+      { initialProps: { from: JAN_FROM, to: JAN_TO } }
+    );
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    fetchMock.mockRejectedValue(new Error("network down"));
+    rerender({ from: FEB_FROM, to: FEB_TO });
+    await waitFor(() => expect(result.current.isWindowError).toBe(true));
+
+    // 前の窓のデータは残す（全画面エラーで隠さない）
+    expect(result.current.isError).toBe(false);
+    expect(result.current.allEvents).toHaveLength(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("prefetchCalendarWindow warms the cache so the next mount shows data immediately", async () => {
+    fetchMock.mockResolvedValue(okResponse(payload()));
+
+    prefetchCalendarWindow(JAN_FROM, JAN_TO);
+    await waitFor(() =>
+      expect(getCachedData(calendarWindowUrl(JAN_FROM, JAN_TO))).toBeDefined()
+    );
+
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
+    // キャッシュ済みなのでスケルトンを経由しない
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.allEvents).toHaveLength(1);
   });
 });

--- a/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.test.ts
@@ -113,6 +113,26 @@ describe("useCalendarData", () => {
     expect(result.current.allEvents[0].backgroundColor).toBe("#3788D8");
   });
 
+  it("exposes member colors and images keyed by name (unset entries omitted)", async () => {
+    fetchMock.mockResolvedValue(
+      okResponse(
+        payload({
+          users: [
+            { id: "u1", name: "Taro", color: "#2563EB", image: "https://img.example/a.jpg" },
+            { id: "u2", name: "Jiro", color: null, image: null },
+          ],
+        })
+      )
+    );
+    const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.memberColors.get("Taro")).toBe("#2563EB");
+    expect(result.current.memberColors.has("Jiro")).toBe(false);
+    expect(result.current.memberImages.get("Taro")).toBe("https://img.example/a.jpg");
+    expect(result.current.memberImages.has("Jiro")).toBe(false);
+  });
+
   it("handles empty reserves response", async () => {
     fetchMock.mockResolvedValue(okResponse(payload({ reserves: [] })));
     const { result } = renderHook(() => useCalendarData(JAN_FROM, JAN_TO));

--- a/app/(protected)/ems/common/hooks/use-calendar-data.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.ts
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
-import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fetchAndCache, getCachedData } from "@/lib/client-cache";
 import { getTextColorForBackground } from "@/lib/calendar-event-rendering";
+import { dayIndexToDateString } from "@/lib/calendar/date-grid";
 
 export interface CalendarEvent {
   textColor: string;
@@ -18,98 +19,176 @@ export interface CalendarEvent {
   borderColor?: string;
 }
 
-interface User {
-  id: string;
-  name: string;
+// /api/calendar のレスポンス（4テーブルを1リクエストに集約。route.ts 参照）
+interface CalendarPayload {
+  users: { id: string; name: string | null }[];
+  lists: { id: number; name: string | null; tag_id: number | null }[];
+  tags: { id: number; name: string | null; color: string }[];
+  reserves: {
+    id: number;
+    user_id: string | null;
+    start: string;
+    end: string;
+    list_id: number | null;
+    isRenting: number | null;
+  }[];
 }
 
-interface List {
-  id: number;
-  name: string;
-  detail: string;
-  image: string;
-  usable: boolean;
-  tag_id: number;
+export function calendarWindowUrl(fromIdx: number, toIdx: number): string {
+  return `/api/calendar?from=${dayIndexToDateString(fromIdx)}&to=${dayIndexToDateString(toIdx)}`;
 }
 
-interface Tag {
-  id: number;
-  name: string;
-  color: string;
+async function fetchCalendarPayload(url: string): Promise<CalendarPayload> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} for ${url}`);
+  }
+  const json = await res.json();
+  // 401/500 の {error} ボディ等を「正常な空」としてキャッシュすると誤った
+  // 空カレンダーがタブ全体に伝播するため、形が違えばエラー扱いにする
+  if (!json || typeof json !== "object" || !Array.isArray((json as { reserves?: unknown }).reserves)) {
+    throw new Error(`unexpected response shape for ${url}`);
+  }
+  return json as CalendarPayload;
 }
 
-interface Reserve {
-  id: number;
-  user_id: string;
-  start: string;
-  end: string;
-  list_id: number;
-  isRenting: number;
+/**
+ * 次に表示しそうな窓（前後の月など）を裏で温める。キャッシュ済みなら何もしない。
+ * 失敗は握りつぶす（実際に表示された時に通常経路で取り直されるため）。
+ */
+export function prefetchCalendarWindow(fromIdx: number, toIdx: number): void {
+  const url = calendarWindowUrl(fromIdx, toIdx);
+  if (getCachedData<CalendarPayload>(url) !== undefined) return;
+  void fetchAndCache(url, () => fetchCalendarPayload(url)).catch(() => {});
 }
 
-// 共有カレンダーのデータ。4エンドポイントは互いに独立なので並行取得され、
-// /api/lists・/api/tags・/api/users のキャッシュは他画面のフックと共有される
-// （タブを行き来しても再マウントで即表示→裏で再検証。use-cached-endpoint 参照）。
-export const useCalendarData = () => {
-  const users = useCachedEndpoint<User>("/api/users");
-  const lists = useCachedEndpoint<List>("/api/lists");
-  const tags = useCachedEndpoint<Tag>("/api/tags");
-  // カレンダーは過去の予約履歴も表示するため、期間フィルタは付けない
-  const reserves = useCachedEndpoint<Reserve>("/api/reserves");
+// 共有カレンダーのデータ。表示中の窓（fromIdx..toIdx、JST day index・inclusive)だけを
+// /api/calendar から1リクエストで取得する。
+//
+// 旧実装は /api/users・/api/lists・/api/tags・/api/reserves を4本並行で叩き、しかも
+// reserves は全履歴を無条件に取得していた（Workers では HTTPリクエスト=Neon接続なので
+// 初回表示のたびに接続ハンドシェイク×4。履歴が増えるほど転送・描画も線形に重くなる）。
+//
+// 窓が変わったとき（月送り・ガント週送り）は、前の窓のデータを表示したまま裏で取得して
+// 差し替える（スケルトンへ戻すと月送りのたびに画面が消えて操作感が悪い）。
+// 取得済み窓はタブを閉じるまで client-cache に残るため、再訪問は即表示→裏で再検証になる。
+export const useCalendarData = (fromIdx: number, toIdx: number) => {
+  const url = calendarWindowUrl(fromIdx, toIdx);
+
+  // state.url は「いま画面に反映されているデータがどの窓のものか」。表示中の url と
+  // 異なる間は isWindowLoading（前の窓を見せながら裏で取得中）になる。
+  const [state, setState] = useState<{ url: string; payload: CalendarPayload } | null>(() => {
+    const cached = getCachedData<CalendarPayload>(url);
+    return cached === undefined ? null : { url, payload: cached };
+  });
+  const [isError, setIsError] = useState(false);
+  const urlRef = useRef(url);
+  // このフックが画面へ反映した最新のリクエスト世代。古い応答の後着を弾く
+  const appliedTicketRef = useRef(0);
+
+  const runFetch = useCallback(
+    async (force: boolean) => {
+      try {
+        const { data, ticket } = await fetchAndCache<CalendarPayload>(
+          url,
+          () => fetchCalendarPayload(url),
+          { force }
+        );
+        // 応答待ちの間に窓が切り替わっていたら反映しない（古い応答の上書き防止）
+        if (urlRef.current !== url) return;
+        if (ticket < appliedTicketRef.current) return;
+        appliedTicketRef.current = ticket;
+        setState({ url, payload: data });
+        setIsError(false);
+      } catch (error) {
+        console.error(`Error fetching ${url}:`, error);
+        if (urlRef.current !== url) return;
+        setIsError(true);
+      }
+    },
+    [url]
+  );
+
+  useEffect(() => {
+    urlRef.current = url;
+    // 窓が変わったらキャッシュがあれば即反映。無ければ前の窓を表示したまま取得を待つ
+    const cached = getCachedData<CalendarPayload>(url);
+    if (cached !== undefined) {
+      setState({ url, payload: cached });
+    }
+    setIsError(false);
+    // キャッシュがあっても裏で必ず再検証する（stale-while-revalidate）。
+    // マウント時の再検証は force しない＝同一URLの同時リクエストは1本にまとまる
+    void runFetch(false);
+  }, [url, runFetch]);
+
+  const payload = state?.payload ?? null;
 
   const allEvents = useMemo<CalendarEvent[]>(() => {
+    if (!payload) return [];
+
     // ユーザーIDをキーにして名前をマッピング
     const idToNameMap1: { [key: string]: string } = {};
-    users.data.forEach((u) => {
-      idToNameMap1[u.id] = u.name;
+    payload.users.forEach((u) => {
+      if (u.name != null) idToNameMap1[u.id] = u.name;
     });
 
     // IDをキーにして機材名と色をマッピング
     const idToNameMap2: { [key: string]: string } = {};
     const idTolistId: { [key: number]: number } = {};
-    lists.data.forEach((item) => {
-      idToNameMap2[item.id] = item.name;
-      idTolistId[item.id] = item.tag_id;
+    payload.lists.forEach((item) => {
+      if (item.name != null) idToNameMap2[item.id] = item.name;
+      if (item.tag_id != null) idTolistId[item.id] = item.tag_id;
     });
 
     const idToColorMap: { [key: string]: string } = {};
-    tags.data.forEach((tag) => {
+    payload.tags.forEach((tag) => {
       idToColorMap[tag.id] = tag.color;
     });
 
-    return reserves.data.map((item) => {
+    return payload.reserves.map((item) => {
       // end は「利用最終日（inclusive）」をそのまま保持する。
       // 旧実装は FullCalendar の排他的 end 用に +1 日していたが、自作カレンダー
       // エンジン（lib/calendar）は inclusive-end 前提のため補正しない。
       const endDate = new Date(item.end);
 
-      const backgroundColor = idToColorMap[idTolistId[item.list_id]] || "#3788D8";
+      const backgroundColor =
+        (item.list_id != null && idToColorMap[idTolistId[item.list_id]]) || "#3788D8";
       const textColor = getTextColorForBackground(backgroundColor);
 
       return {
-        title: idToNameMap2[item.list_id],
+        title: item.list_id != null ? idToNameMap2[item.list_id] : "",
         start: item.start,
         end: endDate,
         allDay: true,
         id: item.id,
-        name: idToNameMap1[item.user_id],
-        isRenting: item.isRenting,
-        list_id: item.list_id,
+        name: item.user_id != null ? idToNameMap1[item.user_id] : "",
+        isRenting: item.isRenting ?? 0,
+        list_id: item.list_id ?? 0,
         backgroundColor,
         borderColor: backgroundColor,
         textColor,
       };
     });
-  }, [users.data, lists.data, tags.data, reserves.data]);
+  }, [payload]);
 
-  const sources = [users, lists, tags, reserves];
-  // 1本でも初回未完了ならスケルトン（キャッシュ表示中の裏再検証では false のまま）
-  const isFetching = sources.some((s) => s.isLoading);
-  // 全画面エラーは「初回ロードに失敗した」ときだけ。取得済み表示は維持する
-  const isError = sources.some((s) => s.isError) && !sources.every((s) => s.hasLoaded);
-  const refetch = async () => {
-    await Promise.all(sources.map((s) => s.refetch()));
+  // 1度も何も表示できていない取得中だけスケルトン（窓の切り替え中は前の窓を出し続ける）
+  const isFetching = payload === null && !isError;
+  // 全画面エラーは「表示できるデータが何も無い」ときだけ
+  const isErrorExposed = payload === null && isError;
+  // 前の窓を表示したまま、いまの窓を取得している
+  const isWindowLoading = state !== null && state.url !== url && !isError;
+  // 前の窓を表示したまま、いまの窓の取得に失敗した（インライン再試行の出し分け用）
+  const isWindowError = state !== null && state.url !== url && isError;
+
+  const refetch = useCallback(() => runFetch(true), [runFetch]);
+
+  return {
+    allEvents,
+    isFetching,
+    isError: isErrorExposed,
+    isWindowLoading,
+    isWindowError,
+    refetch,
   };
-
-  return { allEvents, isFetching, isError, refetch };
 };

--- a/app/(protected)/ems/common/hooks/use-calendar-data.ts
+++ b/app/(protected)/ems/common/hooks/use-calendar-data.ts
@@ -21,7 +21,7 @@ export interface CalendarEvent {
 
 // /api/calendar のレスポンス（4テーブルを1リクエストに集約。route.ts 参照）
 interface CalendarPayload {
-  users: { id: string; name: string | null }[];
+  users: { id: string; name: string | null; color?: string | null; image?: string | null }[];
   lists: { id: number; name: string | null; tag_id: number | null }[];
   tags: { id: number; name: string | null; color: string }[];
   reserves: {
@@ -172,6 +172,24 @@ export const useCalendarData = (fromIdx: number, toIdx: number) => {
     });
   }, [payload]);
 
+  // 部員ごとの本人設定（設定ページのテーマカラー・アイコン）。イベントと同じく名前キー。
+  // 色は memberColorMap の overrides に渡してハッシュ割り当てより優先させる
+  const memberColors = useMemo(() => {
+    const map = new Map<string, string>();
+    payload?.users.forEach((u) => {
+      if (u.name && u.color) map.set(u.name, u.color);
+    });
+    return map;
+  }, [payload]);
+
+  const memberImages = useMemo(() => {
+    const map = new Map<string, string>();
+    payload?.users.forEach((u) => {
+      if (u.name && u.image) map.set(u.name, u.image);
+    });
+    return map;
+  }, [payload]);
+
   // 1度も何も表示できていない取得中だけスケルトン（窓の切り替え中は前の窓を出し続ける）
   const isFetching = payload === null && !isError;
   // 全画面エラーは「表示できるデータが何も無い」ときだけ
@@ -185,6 +203,8 @@ export const useCalendarData = (fromIdx: number, toIdx: number) => {
 
   return {
     allEvents,
+    memberColors,
+    memberImages,
     isFetching,
     isError: isErrorExposed,
     isWindowLoading,

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
 import { toast } from "sonner";
@@ -11,6 +12,8 @@ import { Switch } from "@/components/ui/switch";
 import { useCurrentUser } from "@/hooks/use-current-user";
 import { useCurrentRole } from "@/hooks/use-current-role";
 import { settings as saveAccount } from "@/actions/settings";
+import { compressImage } from "@/lib/image-compress";
+import { MEMBER_PALETTE } from "@/lib/calendar/member-colors";
 import { useUserSettings } from "./hooks/use-user-settings";
 import { AccountSection } from "./_components/AccountSection";
 
@@ -57,6 +60,59 @@ export default function SettingsPage() {
     });
   };
 
+  // アイコン画像: 選択→クライアント圧縮→アップロード→セッション更新。
+  // 保存ボタンは挟まず、ファイルを選んだ時点で反映する（失敗時はトーストで通知）。
+  const avatarInputRef = useRef<HTMLInputElement | null>(null);
+  const [avatarUploading, setAvatarUploading] = useState(false);
+  const onAvatarSelected = async (file: File | undefined) => {
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      toast.error("画像ファイルを選択してください");
+      return;
+    }
+    setAvatarUploading(true);
+    try {
+      // アバターは最大64pxの丸表示なので512pxで十分（機材画像の1600pxより強めに縮める）
+      const compressed = await compressImage(file, {
+        maxEdgePx: 512,
+        recompressThresholdBytes: 100 * 1024,
+      });
+      const res = await fetch("/api/upload/avatar", {
+        method: "POST",
+        headers: { "Content-Type": compressed.type || "application/octet-stream" },
+        body: compressed,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        toast.error(data?.error ?? "アイコンの更新に失敗しました");
+        return;
+      }
+      await update({});
+      toast.success("アイコンを更新しました");
+    } catch {
+      toast.error("アイコンの更新に失敗しました");
+    } finally {
+      setAvatarUploading(false);
+    }
+  };
+
+  // テーマカラー: スワッチをタップした時点で保存する（null = 自動割り当てへ戻す）
+  const [savingColor, startColorSave] = useTransition();
+  const onSelectColor = (color: (typeof MEMBER_PALETTE)[number] | null) => {
+    if (color === (user?.color ?? null)) return;
+    startColorSave(async () => {
+      const result = await saveAccount({
+        color,
+        role: (user?.role as UserRole) || UserRole.USER,
+      });
+      if (result.error) toast.error(result.error);
+      if (result.success) {
+        await update({});
+        toast.success("テーマカラーを保存しました");
+      }
+    });
+  };
+
   const roleLabel = role === UserRole.ADMIN ? "放送部・管理者" : "放送部・部員";
 
   return (
@@ -77,12 +133,74 @@ export default function SettingsPage() {
         {/* プロフィール */}
         <section className="rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-3.5">
-            <div className="flex h-16 w-16 flex-none items-center justify-center rounded-full bg-brand text-2xl font-black text-white">
-              {initialOf(user?.name)}
-            </div>
+            <button
+              type="button"
+              onClick={() => avatarInputRef.current?.click()}
+              disabled={avatarUploading}
+              aria-label="アイコン画像を変更"
+              className="relative h-16 w-16 flex-none rounded-full outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
+            >
+              {user?.image ? (
+                <Image
+                  src={user.image}
+                  alt=""
+                  width={64}
+                  height={64}
+                  className="h-16 w-16 rounded-full object-cover"
+                />
+              ) : (
+                <span
+                  className="flex h-16 w-16 items-center justify-center rounded-full bg-brand text-2xl font-black text-white"
+                  style={user?.color ? { background: user.color } : undefined}
+                >
+                  {initialOf(user?.name)}
+                </span>
+              )}
+              <span className="absolute -bottom-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full border-2 border-white bg-ink text-white">
+                {avatarUploading ? (
+                  <svg
+                    className="h-3 w-3 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                  >
+                    <path d="M21 12a9 9 0 1 1-6.2-8.56" />
+                  </svg>
+                ) : (
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                    <circle cx="12" cy="13" r="4" />
+                  </svg>
+                )}
+              </span>
+            </button>
+            <input
+              ref={avatarInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                // 同じファイルを選び直しても change が発火するようにリセットする
+                e.target.value = "";
+                void onAvatarSelected(file);
+              }}
+            />
             <div className="min-w-0">
               <p className="m-0 truncate text-[17px] font-black text-ink">{user?.name ?? "ゲスト"}</p>
               <p className="m-0 mt-0.5 text-xs text-ink-muted">{roleLabel}</p>
+              <p className="m-0 mt-1 text-[11px] text-ink-faint">タップしてアイコンを変更</p>
             </div>
           </div>
           <p className="m-0 mb-2 mt-4 text-xs font-bold text-ink-muted">表示名</p>
@@ -99,6 +217,61 @@ export default function SettingsPage() {
           >
             {savingName ? "保存中…" : "プロフィールを保存"}
           </button>
+
+          {/* テーマカラー（カレンダーの「色＝人」で自分の予約バーに使う色） */}
+          <p className="m-0 mb-1 mt-5 text-xs font-bold text-ink-muted">テーマカラー</p>
+          <p className="m-0 mb-2.5 text-[11.5px] leading-snug text-ink-faint">
+            カレンダーであなたの予約バーに使われる色。「自動」はメンバー構成から自動で割り当てます
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              disabled={savingColor}
+              onClick={() => onSelectColor(null)}
+              aria-pressed={user?.color == null}
+              className={cn(
+                "flex h-9 items-center rounded-full border-[1.5px] px-3.5 text-xs font-bold transition-colors",
+                user?.color == null
+                  ? "border-ink bg-ink text-white"
+                  : "border-line bg-white text-ink-sub"
+              )}
+            >
+              自動
+            </button>
+            {MEMBER_PALETTE.map((c) => {
+              const selected = user?.color === c;
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  disabled={savingColor}
+                  onClick={() => onSelectColor(c)}
+                  aria-label={`テーマカラー ${c}`}
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex h-9 w-9 items-center justify-center rounded-full border-2 transition-transform",
+                    selected ? "scale-110 border-ink" : "border-transparent"
+                  )}
+                  style={{ background: c }}
+                >
+                  {selected && (
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#fff"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M20 6L9 17l-5-5" />
+                    </svg>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         </section>
 
         {/* 通知 */}

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -1,0 +1,52 @@
+import { db } from '@/lib/db';
+import { currentUser } from '@/lib/auth';
+import { parseDateOnly } from '@/lib/jst-date';
+import { NextResponse } from 'next/server';
+
+// 共有カレンダー専用の集約 GET。
+//
+// 旧実装はクライアントが /api/users・/api/lists・/api/tags・/api/reserves を
+// 4本並行で叩いていた。Workers では HTTP リクエストごとに PrismaClient ＝ Neon 接続
+// （TLS + WebSocket + 認証で 250〜500ms。lib/db.ts 参照）が張られるため、
+// カレンダー初回表示は「接続ハンドシェイク×4」を毎回払っていた。
+// ここに集約すると接続は1本で済み、さらに
+//   - reserves は from/to（表示中の窓）で絞る … 履歴が増えても転送量・描画コストが一定
+//   - 各テーブルは select で最小列に絞る … lists の image/detail（長いURL・長文）を落とす
+// の2点でペイロードも小さくなる。
+//
+// 予約データはログイン部員間で共有される設計（全予約を氏名付きで表示）なので、
+// /api/reserves の GET と同じく認証のみで self-scope はしない。
+export async function GET(request: Request) {
+    try {
+        const user = await currentUser();
+        if (!user?.id) {
+            return NextResponse.json({ error: '認証されていません。' }, { status: 401 });
+        }
+
+        // from/to は必須（YYYY-MM-DD、JST暦日）。無制限の全件取得を許すと
+        // 旧 /api/reserves と同じ「履歴とともに際限なく重くなる」経路が残ってしまう。
+        const { searchParams } = new URL(request.url);
+        const from = parseDateOnly(searchParams.get('from') ?? '');
+        const to = parseDateOnly(searchParams.get('to') ?? '');
+        if (!from || !to || to < from) {
+            return NextResponse.json({ error: 'from / to（YYYY-MM-DD）が不正です。' }, { status: 400 });
+        }
+
+        // 同一リクエスト内なので4クエリとも lib/db.ts が集約した1接続に乗る
+        const [users, lists, tags, reserves] = await Promise.all([
+            db.user.findMany({ select: { id: true, name: true } }),
+            db.list.findMany({ select: { id: true, name: true, tag_id: true } }),
+            db.tag.findMany({ select: { id: true, name: true, color: true }, orderBy: { sortOrder: 'asc' } }),
+            db.reserve.findMany({
+                // 窓と重なる予約（inclusive）。保存値は「JST日付の UTC 00:00」。
+                where: { start: { lte: to }, end: { gte: from } },
+                select: { id: true, user_id: true, start: true, end: true, list_id: true, isRenting: true },
+            }),
+        ]);
+
+        return NextResponse.json({ users, lists, tags, reserves }, { status: 200 });
+    } catch (error) {
+        console.error('Error fetching calendar data:', error);
+        return NextResponse.json({ error: 'Failed to fetch calendar data.' }, { status: 500 });
+    }
+}

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -34,7 +34,8 @@ export async function GET(request: Request) {
 
         // 同一リクエスト内なので4クエリとも lib/db.ts が集約した1接続に乗る
         const [users, lists, tags, reserves] = await Promise.all([
-            db.user.findMany({ select: { id: true, name: true } }),
+            // color/image は本人設定のテーマカラー・アイコン（カレンダーの色とチップ表示に使う）
+            db.user.findMany({ select: { id: true, name: true, color: true, image: true } }),
             db.list.findMany({ select: { id: true, name: true, tag_id: true } }),
             db.tag.findMany({ select: { id: true, name: true, color: true }, orderBy: { sortOrder: 'asc' } }),
             db.reserve.findMany({

--- a/app/api/reserves/route.ts
+++ b/app/api/reserves/route.ts
@@ -2,18 +2,7 @@ import { db } from '@/lib/db';
 import { currentUser } from '@/lib/auth';
 import { notifyInBackground, notifyReservationCreated } from '@/lib/notify';
 import { NextResponse } from 'next/server';
-import { todayJstAsUtcMidnight } from '@/lib/jst-date';
-
-// YYYY-MM-DD を UTC 深夜0時の Date として厳密にパースする。
-// 正規表現だけだと「2026-13-01」（Invalid Date → Prisma が例外 → 500）や
-// 「2026-02-30」（3月2日へ静かに繰り上がる）が素通りするため、
-// 逆変換の一致まで確認して暦として実在する日付だけを受け付ける。
-function parseDateOnly(value: string): Date | null {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
-    const date = new Date(`${value}T00:00:00Z`);
-    if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(value)) return null;
-    return date;
-}
+import { parseDateOnly, todayJstAsUtcMidnight } from '@/lib/jst-date';
 
 export async function GET(request: Request) {
     try {

--- a/app/api/upload/avatar/route.ts
+++ b/app/api/upload/avatar/route.ts
@@ -1,0 +1,81 @@
+// app/api/upload/avatar/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { currentUser } from '@/lib/auth';
+import { db } from '@/lib/db';
+
+// プロフィールアイコンのアップロード。機材画像の /api/upload と違い管理操作では
+// ないため hasManagerAccess ではなく「本人ログイン」で守る。更新できるのは常に
+// セッション本人の User.image だけなので、なりすまし・他人の上書きは成立しない。
+//
+// クライアントは lib/image-compress で 512px へ縮小してから送る前提だが、
+// 圧縮は fail-open（未対応環境では原本のまま）なので、サーバ側でも上限を敷く。
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+
+export async function POST(req: NextRequest) {
+  const user = await currentUser();
+  if (!user?.id) {
+    return NextResponse.json({ error: '認証されていません。' }, { status: 401 });
+  }
+
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.startsWith('image/')) {
+    return NextResponse.json({ error: '画像ファイルを指定してください。' }, { status: 400 });
+  }
+
+  // 配信はカスタムドメイン。DB(User.image) にはここで組み立てた絶対 URL を保存する。
+  const baseUrl = process.env.R2_PUBLIC_BASE_URL;
+  if (!baseUrl) {
+    console.error('R2_PUBLIC_BASE_URL is not set');
+    return NextResponse.json({ error: 'Image storage is not configured' }, { status: 500 });
+  }
+
+  try {
+    const body = await req.arrayBuffer();
+    if (body.byteLength === 0) {
+      return NextResponse.json({ error: '画像が空です。' }, { status: 400 });
+    }
+    if (body.byteLength > MAX_AVATAR_BYTES) {
+      return NextResponse.json({ error: '画像が大きすぎます（5MBまで）。' }, { status: 413 });
+    }
+
+    // R2 の put() は同一キーをエラー無しで上書きするため UUID でキーを一意化する。
+    // キーが毎回変わることで immutable キャッシュでも差し替えが即時反映される。
+    const base = baseUrl.replace(/\/$/, '');
+    const key = `avatars/${user.id}/${crypto.randomUUID()}`;
+
+    const { env } = getCloudflareContext();
+    await env.IMAGES_BUCKET.put(key, body, {
+      httpMetadata: {
+        contentType,
+        cacheControl: 'public, max-age=31536000, immutable',
+      },
+    });
+    const url = `${base}/${key}`;
+
+    // 差し替え前の URL を控えてから更新し、自分の旧アバターだけ R2 から掃除する
+    // （プレフィックス確認により機材画像など他のオブジェクトは対象外）。
+    // 掃除に失敗しても表示には影響しないため、エラーはログのみで握りつぶす。
+    const prev = await db.user.findUnique({
+      where: { id: user.id },
+      select: { image: true },
+    });
+    await db.user.update({ where: { id: user.id }, data: { image: url } });
+
+    const ownPrefix = `${base}/avatars/${user.id}/`;
+    if (prev?.image?.startsWith(ownPrefix)) {
+      const oldKey = prev.image.slice(base.length + 1);
+      try {
+        await env.IMAGES_BUCKET.delete(oldKey);
+      } catch (error) {
+        console.error('Failed to delete old avatar:', error);
+      }
+    }
+
+    return NextResponse.json({ url });
+  } catch (error: any) {
+    console.error('Avatar upload API error:', error);
+    return NextResponse.json({ error: 'Image upload failed', details: error?.message }, { status: 500 });
+  }
+}

--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
 
-// children は子のpage.tsx
-const AuthLayout = ({ children }: {children: React.ReactNode}) => {
+// children は子の page.tsx（login / register / reset / new-password / error など認証系の全画面）。
+// アプリ本体の刷新後デザイン（navy ヘッダー + brand ブルー）に合わせ、
+// 旧テンプレートの水色グラデーション背景を navy 基調 + 上部にごく淡い brand の光へ置き換える。
+// bg-navy が background-color、radial-gradient が background-image なので両立する。
+const AuthLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="h-full flex items-center justify-center px-4
-    bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))]
-    from-sky-400 to-blue-800">
-        {children}
+    <div
+      className="flex min-h-dvh items-center justify-center bg-navy px-4 py-10
+      bg-[radial-gradient(ellipse_at_top,_rgba(46,144,250,0.25),_transparent_65%)]"
+    >
+      {children}
     </div>
   )
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,12 +1,10 @@
 import { LoginForm } from '@/components/auth/login-form'
 import React from 'react'
 
+// 素の <div> で包むと flex アイテムがコンテンツ幅に縮み、
+// CardWrapper の w-full / max-w が効かず極端に細くなる（直接返す）
 const LoginPage = () => {
-  return (
-    <div>
-        <LoginForm />
-    </div>
-  )
+  return <LoginForm />
 }
 
 export default LoginPage

--- a/app/auth/new-verification/page.tsx
+++ b/app/auth/new-verification/page.tsx
@@ -1,11 +1,9 @@
 import { NewVerificationForm } from "@/components/auth/new-verification-form"
 
+// 素の <div> で包むと flex アイテムがコンテンツ幅に縮み、
+// CardWrapper の w-full / max-w が効かず極端に細くなる（直接返す）
 const NewVerificationPage = () => {
-  return (
-    <div>
-        <NewVerificationForm />
-    </div>
-  )
+  return <NewVerificationForm />
 }
 
 export default NewVerificationPage

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,12 +1,10 @@
 import { RegisterForm } from '@/components/auth/register-form'
 import React from 'react'
 
+// 素の <div> で包むと flex アイテムがコンテンツ幅に縮み、
+// CardWrapper の w-full / max-w が効かず極端に細くなる（直接返す）
 const RegisterPage = () => {
-  return (
-    <div>
-        <RegisterForm />
-    </div>
-  )
+  return <RegisterForm />
 }
 
 export default RegisterPage

--- a/auth.ts
+++ b/auth.ts
@@ -91,6 +91,10 @@ export const {
         session.user.name = token.name;
         session.user.email = token.email as string;
         session.user.isOAuth = token.isOAuth as boolean;
+        // アイコンとテーマカラー（設定ページで本人が変更できる）。
+        // token 側は lib/jwt-refresh.ts が DB から反映する
+        session.user.image = (token.picture as string | null | undefined) ?? null;
+        session.user.color = (token.color as string | null | undefined) ?? null;
       }
 
       /* 更新されたセッションを返す */

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -17,6 +17,8 @@ interface AbsEmsR2Bucket {
     value: ArrayBuffer | ArrayBufferView | ReadableStream | Blob | string | null,
     options?: { httpMetadata?: { contentType?: string; cacheControl?: string } },
   ): Promise<unknown>;
+  // アバター差し替え時の旧オブジェクト削除に使う
+  delete(key: string): Promise<void>;
 }
 
 // Email Sending バインディング（wrangler.jsonc の send_email）。

--- a/components/auth/back-button.tsx
+++ b/components/auth/back-button.tsx
@@ -15,7 +15,7 @@ export const BackButton = ({
     return (
         <Button
             variant="link"
-            className="font-nomal w-full"
+            className="w-full font-normal text-[13px] text-ink-muted hover:text-brand"
             size="sm"
             asChild
         >

--- a/components/auth/card-wrapper.tsx
+++ b/components/auth/card-wrapper.tsx
@@ -26,8 +26,9 @@ export const CardWrapper = ({
     showSocial
 }: CardWrapperProps) => {
     // 固定幅だと CSS 幅360px級の端末（Galaxy 等）で左右が見切れるため max-width にする
+    // （スマホでは w-full で画面幅いっぱい−px-4、広い画面では 420px）
     return (
-        <Card className="w-full max-w-[370px] md:max-w-[450px] shadow-md">
+        <Card className="w-full max-w-[420px] rounded-2xl border-0 bg-white shadow-xl">
             <CardHeader>
                 <Header label={headerLabel} />
             </CardHeader>

--- a/components/auth/card-wrapper.tsx
+++ b/components/auth/card-wrapper.tsx
@@ -26,9 +26,10 @@ export const CardWrapper = ({
     showSocial
 }: CardWrapperProps) => {
     // 固定幅だと CSS 幅360px級の端末（Galaxy 等）で左右が見切れるため max-width にする
-    // （スマホでは w-full で画面幅いっぱい−px-4、広い画面では 420px）
+    // （スマホでは w-full で画面幅いっぱい−px-4、タブレット以上は 560px。
+    //   420px だと PC で細長く見えるという指摘があり広げた）
     return (
-        <Card className="w-full max-w-[420px] rounded-2xl border-0 bg-white shadow-xl">
+        <Card className="w-full max-w-[440px] rounded-2xl border-0 bg-white shadow-xl md:max-w-[560px]">
             <CardHeader>
                 <Header label={headerLabel} />
             </CardHeader>

--- a/components/auth/header.tsx
+++ b/components/auth/header.tsx
@@ -1,30 +1,32 @@
-import { Poppins } from "next/font/google";
-
-import { cn } from "@/lib/utils";
-
-const font = Poppins({
-    subsets: ["latin"],
-    weight: ["600"],
-})
+import Image from "next/image";
 
 interface HeaderProps {
     label: string;
 };
 
+// 認証カード共通のヘッダー。旧テンプレートの「🔐 Auth」（Poppins）から
+// アプリのアイコン + ロゴタイプへ差し替え（UI刷新後のデザインに合わせる）。
 export const Header = ({
     label,
 }: HeaderProps) => {
     return (
-        <div className="w-full flex flex-col gap-y-4 items-center justify-center">
-            <h1 className={cn(
-                "text-3xl font-semibold",
-                font.className,
-            )}>
-                🔐 Auth
-            </h1>
-            <p className="text-muted-foreground text-sm">
-                {label}
-            </p>
+        <div className="flex w-full flex-col items-center justify-center gap-y-3">
+            <Image
+                src="/ABS-EMS512_rounded.png"
+                alt=""
+                width={56}
+                height={56}
+                priority
+                className="h-14 w-14"
+            />
+            <div className="text-center">
+                <h1 className="m-0 text-xl font-black tracking-wide text-ink">
+                    ABS EMS
+                </h1>
+                <p className="m-0 mt-1 text-sm text-ink-muted">
+                    {label}
+                </p>
+            </div>
         </div>
     )
 }

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -95,7 +95,7 @@ export const LoginForm = () => {
                                         <FormControl>
                                             <Input
                                                 {...field}
-                                                className="text-[16px]"
+                                                className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                                 disabled={isPending}
                                                 placeholder="123456"
                                             />
@@ -116,7 +116,7 @@ export const LoginForm = () => {
                                             <FormControl>
                                                 <Input
                                                     {...field}
-                                                    className="text-[16px]"
+                                                    className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                                     disabled={isPending}
                                                     placeholder="daichi@example.com"
                                                     type="email"
@@ -135,7 +135,7 @@ export const LoginForm = () => {
                                             <FormControl>
                                                 <Input
                                                     {...field}
-                                                    className="text-[16px]"
+                                                    className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                                     disabled={isPending}
                                                     placeholder="******"
                                                     type="password"
@@ -145,7 +145,7 @@ export const LoginForm = () => {
                                                 size="sm"
                                                 variant="link"
                                                 asChild
-                                                className="px-0 font-nomal"
+                                                className="px-0 text-[12.5px] font-normal text-brand"
                                             >
                                                 <Link href="/auth/reset">
                                                     パスワードをお忘れですか？
@@ -163,7 +163,7 @@ export const LoginForm = () => {
                     <Button
                         disabled={isPending}
                         type="submit"
-                        className="w-full"
+                        className="h-[46px] w-full rounded-xl bg-brand text-sm font-bold text-white hover:bg-brand-dark"
                     >
                         {showTwoFactor ? "確認する" : "ログイン"}
                     </Button>

--- a/components/auth/new-password-form.tsx
+++ b/components/auth/new-password-form.tsx
@@ -73,7 +73,7 @@ export const NewPasswordForm = () => {
                                         <Input
                                             {...field}
                                             disabled={isPending}
-                                            className="text-[16px]"
+                                            className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                             placeholder="10文字以上で入力"
                                             type="password"
                                         />
@@ -88,7 +88,7 @@ export const NewPasswordForm = () => {
                     <Button
                         disabled={isPending}
                         type="submit"
-                        className="w-full"
+                        className="h-[46px] w-full rounded-xl bg-brand text-sm font-bold text-white hover:bg-brand-dark"
                     >
                         パスワードを再設定する
                     </Button>

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -77,7 +77,7 @@ export const RegisterForm = () => {
                                         <Input
                                             {...field}
                                             disabled={isPending}
-                                            className="text-[16px]"
+                                            className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                             placeholder="青山 太郎"
                                         />
                                     </FormControl>
@@ -95,7 +95,7 @@ export const RegisterForm = () => {
                                         <Input
                                             {...field}
                                             disabled={isPending}
-                                            className="text-[16px]"
+                                            className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                             placeholder="daichi@example.com"
                                             type="email"
                                         />
@@ -114,7 +114,7 @@ export const RegisterForm = () => {
                                         <Input
                                             {...field}
                                             disabled={isPending}
-                                            className="text-[16px]"
+                                            className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                             placeholder="10文字以上で入力"
                                             type="password"
                                         />
@@ -129,7 +129,7 @@ export const RegisterForm = () => {
                     <Button
                         disabled={isPending}
                         type="submit"
-                        className="w-full"
+                        className="h-[46px] w-full rounded-xl bg-brand text-sm font-bold text-white hover:bg-brand-dark"
                     >
                         アカウント登録
                     </Button>

--- a/components/auth/reset-form.tsx
+++ b/components/auth/reset-form.tsx
@@ -69,7 +69,7 @@ export const ResetForm = () => {
                                         <Input
                                             {...field}
                                             disabled={isPending}
-                                            className="text-[16px]"
+                                            className="h-[46px] rounded-xl border-[1.5px] border-line bg-[#F9FAFB] px-3.5 text-[16px] focus-visible:border-brand focus-visible:bg-white focus-visible:ring-0"
                                             placeholder="daichi@example.com"
                                             type="email"
                                         />
@@ -84,7 +84,7 @@ export const ResetForm = () => {
                     <Button
                         disabled={isPending}
                         type="submit"
-                        className="w-full"
+                        className="h-[46px] w-full rounded-xl bg-brand text-sm font-bold text-white hover:bg-brand-dark"
                     >
                         再設定用メールを送る
                     </Button>

--- a/components/auth/social.tsx
+++ b/components/auth/social.tsx
@@ -2,60 +2,41 @@
 
 import { signIn } from "next-auth/react"
 import { FcGoogle } from "react-icons/fc"
-import { FaGithub } from "react-icons/fa"
 import { useSearchParams } from "next/navigation"
 import { useState } from "react"
 
 import { DEFAULT_LOGIN_REDIRECT } from "@/routes"
 
+// ソーシャルログイン。GitHub は部員に利用者がいないため導線を撤去し、
+// Google のみをラベル付きの全幅ボタンで出す（auth.config.ts の provider 自体は
+// 残してあるので、万一 GitHub 連携済みアカウントがあっても API 経路は生きている）。
 export const Social = () => {
     const searchParams = useSearchParams();
     const callbackUrl = searchParams.get("callbackUrl");
 
-    const [isLoadingGoogle, setIsLoadingGoogle] = useState(false);
-    const [isLoadingGithub, setIsLoadingGithub] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
 
-    const onClick = async (provider: "google" | "github") => {
-        if (provider === "google") {
-            setIsLoadingGoogle(true);
-        } else {
-            setIsLoadingGithub(true);
-        }
-
+    const onClick = async () => {
+        setIsLoading(true);
         try {
-            await signIn(provider, {
+            await signIn("google", {
                 callbackUrl: callbackUrl || DEFAULT_LOGIN_REDIRECT,
             });
         } finally {
-            setIsLoadingGoogle(false);
-            setIsLoadingGithub(false);
+            setIsLoading(false);
         }
     };
 
-    const baseClass =
-        "flex h-11 w-full items-center justify-center rounded-xl border-[1.5px] border-line bg-white transition-colors hover:bg-surface disabled:opacity-60";
-
     return (
-        <div className="flex w-full items-center gap-x-2">
-            <button
-                type="button"
-                onClick={() => onClick("google")}
-                disabled={isLoadingGoogle}
-                className={baseClass}
-                aria-label="Googleでログイン"
-            >
-                {isLoadingGoogle ? <Spinner /> : <FcGoogle className="h-5 w-5" />}
-            </button>
-            <button
-                type="button"
-                onClick={() => onClick("github")}
-                disabled={isLoadingGithub}
-                className={baseClass}
-                aria-label="GitHubでログイン"
-            >
-                {isLoadingGithub ? <Spinner /> : <FaGithub className="h-5 w-5" />}
-            </button>
-        </div>
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={isLoading}
+            className="flex h-11 w-full items-center justify-center gap-2 rounded-xl border-[1.5px] border-line bg-white text-[13.5px] font-bold text-ink-sub transition-colors hover:bg-surface disabled:opacity-60"
+        >
+            {isLoading ? <Spinner /> : <FcGoogle className="h-5 w-5" />}
+            Googleでログイン
+        </button>
     );
 };
 

--- a/components/calendar/EquipmentGantt.tsx
+++ b/components/calendar/EquipmentGantt.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { dayIndexToUtcDate, DOW_LABELS } from "@/lib/calendar/date-grid";
 
@@ -9,6 +10,8 @@ export interface GanttBar<T = unknown> {
   endIdx: number; // inclusive
   color: string;
   initial?: string;
+  /** 本人設定のアイコン画像。あればイニシャルの代わりに表示する */
+  image?: string;
   label?: string;
   data?: T;
 }
@@ -132,10 +135,20 @@ export function EquipmentGantt<T = unknown>({
                       background: bar.color,
                     }}
                   >
-                    {bar.initial && (
-                      <span className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full bg-white/30 text-[9px] font-bold text-white">
-                        {bar.initial}
-                      </span>
+                    {bar.image ? (
+                      <Image
+                        src={bar.image}
+                        alt=""
+                        width={18}
+                        height={18}
+                        className="h-[18px] w-[18px] flex-none rounded-full object-cover"
+                      />
+                    ) : (
+                      bar.initial && (
+                        <span className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full bg-white/30 text-[9px] font-bold text-white">
+                          {bar.initial}
+                        </span>
+                      )
                     )}
                     {bar.label && (
                       <span className="truncate text-[9px] font-bold text-white">{bar.label}</span>

--- a/components/calendar/EventDetailPopover.tsx
+++ b/components/calendar/EventDetailPopover.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { memberColor, memberInitial } from "@/lib/calendar/member-colors";
 
 // 予約バーの詳細（誰が・何を・いつまで）。月カレンダーで選択したバーの内容を
@@ -14,21 +15,34 @@ export interface EventDetail {
 export function EventDetailPopover({
   detail,
   color: colorProp,
+  image,
 }: {
   detail: EventDetail;
   /** バー側と同じ色割り当て（memberColorMap）を使う場合に渡す。省略時はハッシュ色 */
   color?: string;
+  /** 本人設定のアイコン画像。あればイニシャルの代わりに表示する */
+  image?: string;
 }) {
   const color = colorProp ?? memberColor(detail.who);
   return (
     <div className="rounded-2xl bg-navy p-[13px] px-[15px] text-white">
       <div className="flex items-center gap-2.5">
-        <div
-          className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-full text-[13px] font-bold text-white"
-          style={{ background: color }}
-        >
-          {memberInitial(detail.who)}
-        </div>
+        {image ? (
+          <Image
+            src={image}
+            alt=""
+            width={30}
+            height={30}
+            className="h-[30px] w-[30px] flex-none rounded-full object-cover"
+          />
+        ) : (
+          <div
+            className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-full text-[13px] font-bold text-white"
+            style={{ background: color }}
+          >
+            {memberInitial(detail.who)}
+          </div>
+        )}
         <div className="min-w-0 flex-1">
           <p className="m-0 truncate text-[13.5px] font-bold">
             {detail.who} が {detail.equipment} を予約

--- a/components/calendar/MemberChips.tsx
+++ b/components/calendar/MemberChips.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { memberColor, memberInitial } from "@/lib/calendar/member-colors";
 
@@ -16,6 +17,8 @@ export interface MemberChipsProps {
   collapseLimit?: number;
   /** バー側と同じ色割り当て（memberColorMap）を使う場合に渡す。省略時はハッシュ色 */
   colorOf?: (name: string) => string;
+  /** 本人設定のアイコン画像。返り値があればイニシャルの代わりに表示する */
+  imageOf?: (name: string) => string | undefined;
 }
 
 export function MemberChips({
@@ -25,16 +28,24 @@ export function MemberChips({
   className,
   collapseLimit = 10,
   colorOf = memberColor,
+  imageOf,
 }: MemberChipsProps) {
   const [expanded, setExpanded] = useState(false);
 
-  const items: { name: string | null; label: string; initial: string; color: string }[] = [
+  const items: {
+    name: string | null;
+    label: string;
+    initial: string;
+    color: string;
+    image?: string;
+  }[] = [
     { name: null, label: "すべて", initial: "全", color: "#475467" },
     ...members.map((name) => ({
       name,
       label: name,
       initial: memberInitial(name),
       color: colorOf(name),
+      image: imageOf?.(name),
     })),
   ];
 
@@ -65,12 +76,22 @@ export function MemberChips({
               on ? "border-ink bg-ink" : "border-line bg-white"
             )}
           >
-            <span
-              className="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold text-white"
-              style={{ background: it.color }}
-            >
-              {it.initial}
-            </span>
+            {it.image ? (
+              <Image
+                src={it.image}
+                alt=""
+                width={20}
+                height={20}
+                className="h-5 w-5 flex-none rounded-full object-cover"
+              />
+            ) : (
+              <span
+                className="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold text-white"
+                style={{ background: it.color }}
+              >
+                {it.initial}
+              </span>
+            )}
             <span className={cn("text-[11.5px] font-bold", on ? "text-white" : "text-ink-sub")}>
               {it.label}
             </span>

--- a/lib/calendar/member-colors.test.ts
+++ b/lib/calendar/member-colors.test.ts
@@ -56,6 +56,32 @@ describe("memberColorMap", () => {
     }
   });
 
+  it("overrides（本人選択の色）はハッシュ割り当てより優先される", () => {
+    const overrides = new Map([["川崎蒼汰", "#12B76A"]]);
+    const map = memberColorMap(["川崎蒼汰", "星野琉生"], [], overrides);
+    expect(map.get("川崎蒼汰")).toBe("#12B76A");
+  });
+
+  it("overrides が使った色は自動割り当ての空き探索から除外される", () => {
+    // パレット16色を使い切る人数構成で、選択者の色が自動勢と重複しないこと
+    const autoNames = Array.from({ length: 15 }, (_, i) => `部員${i}`);
+    const overrides = new Map([["選択者", "#2563EB"]]);
+    const map = memberColorMap([...autoNames, "選択者"], [], overrides);
+    const autoColors = autoNames.map((n) => map.get(n));
+    expect(autoColors).not.toContain("#2563EB");
+    expect(new Set([...autoColors, "#2563EB"]).size).toBe(16);
+  });
+
+  it("同じ色を選んだ二人はどちらもその色になる（本人の選択を尊重）", () => {
+    const overrides = new Map([
+      ["A", "#EF4444"],
+      ["B", "#EF4444"],
+    ]);
+    const map = memberColorMap(["A", "B"], [], overrides);
+    expect(map.get("A")).toBe("#EF4444");
+    expect(map.get("B")).toBe("#EF4444");
+  });
+
   it("優先リスト（表示中の月の部員）は履歴が何人いても互いに異なる色になる", () => {
     // 卒業生など履歴上の名前が一意枠(16色)を食いつぶしても、
     // いま表示している月の部員同士は同色にならないことを固定する

--- a/lib/calendar/member-colors.ts
+++ b/lib/calendar/member-colors.ts
@@ -1,8 +1,9 @@
 // 予約者（部員）ごとの安定した色割り当て。
-// 月カレンダーは「色＝人」で予約バーを塗る（UI刷新案 3a）。DB に部員色が無いため、
-// 名前をキーに固定パレットへ決定的に写像する（同じ名前は常に同じ色）。
+// 月カレンダーは「色＝人」で予約バーを塗る（UI刷新案 3a）。
+// 本人が設定ページで選んだ色（User.color）があればそれを最優先し、
+// 未選択の部員は名前をキーに固定パレットへ決定的に写像する（同じ名前は常に同じ色）。
 
-const MEMBER_PALETTE = [
+export const MEMBER_PALETTE = [
   "#2563EB", // blue
   "#12B76A", // green
   "#F79009", // orange
@@ -47,13 +48,25 @@ export function memberColor(name: string | null | undefined): string {
  * （卒業生など履歴上の名前が一意枠を食いつぶすのを防ぐ）。
  * 各グループ内は名前昇順で割り当てるため、同じメンバー集合なら結果は安定
  * （メンバーが増減すると他の人の色が変わり得るのは一意性とのトレードオフ）。
+ *
+ * overrides には「本人が設定ページで選んだ色（User.color）」を渡す。該当者は
+ * 無条件でその色になり、使ったパレット枠は自動割り当ての空き探索から除外する
+ * （自動勢が本人選択の色に重ならないように。選択者同士の同色は本人の意思なので許容）。
  */
 export function memberColorMap(
   names: (string | null | undefined)[],
-  priorityNames: (string | null | undefined)[] = []
+  priorityNames: (string | null | undefined)[] = [],
+  overrides?: ReadonlyMap<string, string>
 ): Map<string, string> {
   const map = new Map<string, string>();
   const used = new Set<number>();
+  if (overrides) {
+    for (const [name, color] of overrides) {
+      map.set(name, color);
+      const idx = (MEMBER_PALETTE as readonly string[]).indexOf(color);
+      if (idx >= 0) used.add(idx);
+    }
+  }
   const assign = (list: (string | null | undefined)[]) => {
     const unique = [...new Set(list.filter((n): n is string => !!n))].sort();
     for (const name of unique) {

--- a/lib/image-compress.ts
+++ b/lib/image-compress.ts
@@ -9,16 +9,29 @@ const RECOMPRESS_THRESHOLD_BYTES = 300 * 1024; // これ以下は十分軽いの
 const MAX_EDGE_PX = 1600;
 const JPEG_QUALITY = 0.85;
 
-export async function compressImage(file: File): Promise<File> {
+export interface CompressImageOptions {
+  /** 長辺の上限（px）。アバターなど小さい表示しかしない用途で下げる */
+  maxEdgePx?: number;
+  /** このサイズ以下は再圧縮しない（既定 300KB）。小さい表示用途では下げる */
+  recompressThresholdBytes?: number;
+}
+
+export async function compressImage(
+  file: File,
+  options: CompressImageOptions = {}
+): Promise<File> {
+  const maxEdgePx = options.maxEdgePx ?? MAX_EDGE_PX;
+  const recompressThresholdBytes =
+    options.recompressThresholdBytes ?? RECOMPRESS_THRESHOLD_BYTES;
   try {
     if (!file.type.startsWith("image/")) return file;
     // GIF はアニメーション、SVG はベクタ情報が失われるため対象外
     if (file.type === "image/gif" || file.type === "image/svg+xml") return file;
-    if (file.size <= RECOMPRESS_THRESHOLD_BYTES) return file;
+    if (file.size <= recompressThresholdBytes) return file;
     if (typeof createImageBitmap !== "function") return file;
 
     const bitmap = await createImageBitmap(file);
-    const scale = Math.min(1, MAX_EDGE_PX / Math.max(bitmap.width, bitmap.height));
+    const scale = Math.min(1, maxEdgePx / Math.max(bitmap.width, bitmap.height));
     const width = Math.max(1, Math.round(bitmap.width * scale));
     const height = Math.max(1, Math.round(bitmap.height * scale));
 

--- a/lib/jst-date.ts
+++ b/lib/jst-date.ts
@@ -17,3 +17,14 @@ export function todayJstDateString(): string {
 export function todayJstAsUtcMidnight(): Date {
   return new Date(`${todayJstDateString()}T00:00:00Z`);
 }
+
+// YYYY-MM-DD を UTC 深夜0時の Date として厳密にパースする。
+// 正規表現だけだと「2026-13-01」（Invalid Date → Prisma が例外 → 500）や
+// 「2026-02-30」（3月2日へ静かに繰り上がる）が素通りするため、
+// 逆変換の一致まで確認して暦として実在する日付だけを受け付ける。
+export function parseDateOnly(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime()) || !date.toISOString().startsWith(value)) return null;
+  return date;
+}

--- a/lib/jwt-refresh.ts
+++ b/lib/jwt-refresh.ts
@@ -38,6 +38,10 @@ export async function refreshJwtToken({ token, user, trigger }: JwtParams) {
   token.email = existingUser.email;
   token.role = existingUser.role;
   token.isTwoFactorEnabled = existingUser.isTwoFactorEnabled;
+  // アイコンは JWT 標準の picture クレームに載せる（session.user.image の元）。
+  // テーマカラーともども、設定ページでの変更後は update({}) 経由でここに反映される。
+  token.picture = existingUser.image;
+  token.color = existingUser.color;
   token.refreshedAt = Date.now();
 
   return token;

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -6,6 +6,8 @@ export type ExtendedUser = DefaultSession["user"] & {
     role: UserRole
     isTwoFactorEnabled: boolean;
     isOAuth: boolean;
+    // カレンダー「色＝人」のテーマカラー（#RRGGBB）。null は自動割り当て
+    color: string | null;
 }
 
 declare module "next-auth" {

--- a/prisma/migrations/20260706164649_add_user_color/migration.sql
+++ b/prisma/migrations/20260706164649_add_user_color/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "color" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,9 @@ model User {
   email         String?   @unique
   emailVerified DateTime? @map("email_verified")
   image         String?
+  // カレンダーの「色＝人」で使う本人選択のテーマカラー（#RRGGBB）。
+  // null は未選択＝従来どおり名前ハッシュで自動割り当て（lib/calendar/member-colors.ts）。
+  color         String?
   password      String?
   role          UserRole  @default(USER)
   accounts      Account[]

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,10 +1,16 @@
 import { UserRole } from "@prisma/client";
 import * as z from "zod";
 
+import { MEMBER_PALETTE } from "@/lib/calendar/member-colors";
+
 export const SettingsSchema = z.object({
     name: z.optional(z.string()),
     isTwoFactorEnabled: z.optional(z.boolean()),
     role: z.enum([UserRole.ADMIN, UserRole.USER]),
+    // カレンダーのテーマカラー。パレット外の任意色は受け付けない
+    // （「色＝人」の視認性とダーク文字色の判定をパレット前提で保っているため）。
+    // null は「自動（名前ハッシュ）」へ戻す
+    color: z.optional(z.nullable(z.enum(MEMBER_PALETTE))),
     email: z.optional(z.string().email()),
     password: z.optional(z.string().min(10, {
         message: "10文字以上のパスワードにしてください"


### PR DESCRIPTION
## 概要

本日 develop に統合した5本の変更を本番リリースします。

### 1. 共通カレンダーのパフォーマンス改善（perf）
- users/lists/tags/reserves の4本のHTTP取得を新設の `/api/calendar` 1本に集約（Workers では HTTPリクエスト=Neon接続のため、接続ハンドシェイク 4→1）
- 予約は表示中の窓（月グリッド／ガント14日）だけ `from`/`to` で取得し、`select` で最小列に絞り込み（機材画像URL・説明文を落とす）。履歴が増えても転送・描画コストが一定に
- 月送りは前後月をプリフェッチして実質待ちゼロ。窓の切替中は前の表示を保持（スケルトンに戻さない）、失敗時はインライン再試行

### 2. テーマカラー・アイコン画像のユーザ設定（feat）
- **⚠️ migration あり**: `20260706164649_add_user_color`（`users.color` 列追加）。マージで CI の `prisma migrate deploy` が本番に適用されます
- 設定ページに16色パレット＋「自動」のテーマカラー選択と、アイコン画像のアップロード（クライアントで512pxに圧縮→R2 `avatars/{userId}/`、差し替え時に旧画像を削除）を追加
- 本人が選んだ色はカレンダーの自動割り当てより優先され、自動勢はその色を避ける
- セッション(JWT)に image/color を伝播。Google ログインの部員は既存の Google アイコンが即表示される
- カレンダーのバー色・部員チップ・詳細カード・ガント、ヘッダーメニューに反映

### 3. 認証画面のUI刷新（fix）
- 旧テンプレートの水色グラデーション＋「🔐 Auth」を、アプリ本体と同じ navy 背景＋白カード＋ABS EMS ロゴに統一（login/register/reset/new-password/error）
- 入力欄・ボタンも設定ページ等と同じスタイルに

### 4. 認証カードの幅修正（fix）
- login/register/new-verification がフォームを素の `<div>` で包んでおり、flex アイテムがコンテンツ幅（約260px）に縮んで `max-w` が効いていなかった問題を解消。カード幅は 440px / PC 560px

### 5. GitHub ログイン導線の撤去（fix）
- 部員に利用者がいないため UI から撤去し、Google をラベル付き全幅ボタンに。provider 自体は残してあるため既存の GitHub 連携アカウントの経路は塞がない

## テスト
- vitest 414件 / tsc / lint / `next build` すべて通過
- dev サーバ＋Chrome で実機確認済み: カレンダー描画・月送り（プリフェッチ）・ガント、テーマカラー選択→カレンダー反映、アバター表示、認証画面の表示と Google ログイン遷移

## リリース後の確認事項
- [ ] `users.color` migration が本番に適用されたこと
- [ ] アバターアップロードの実動作（R2 書き込みはローカルで検証不可のため本番で要確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQKp4tERqX2DTEr7daJSnx