### PR TITLE
メンバー権限管理（ロール変更・除名）＋ DB 監査カラム整備

### DIFF
--- a/app/(protected)/settings/_components/WorkspaceMembers.tsx
+++ b/app/(protected)/settings/_components/WorkspaceMembers.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { useSession } from "next-auth/react";
+import { WorkspaceRole } from "@prisma/client";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useCurrentUser } from "@/hooks/use-current-user";
+import { useWorkspaceMembers, type WorkspaceMember } from "@/hooks/use-workspace-members";
+import { apiMutate, ApiMutateError } from "@/lib/api-mutate";
+import { canAssignRole, canManageMember } from "@/lib/workspace";
+import { memberInitial } from "@/lib/calendar/member-colors";
+
+const ROLE_LABEL: Record<WorkspaceRole, string> = {
+  OWNER: "オーナー",
+  ADMIN: "管理者",
+  MEMBER: "メンバー",
+};
+const ROLES: WorkspaceRole[] = [
+  WorkspaceRole.OWNER,
+  WorkspaceRole.ADMIN,
+  WorkspaceRole.MEMBER,
+];
+
+/**
+ * ワークスペースのメンバー管理（設定ページの管理者ブロック内）。
+ * ロール変更と除名。ルールはサーバーと同じ lib/workspace.ts の純関数で出し分ける
+ * （最終的な強制はサーバー側 /api/workspaces/current/members/[userId]）。
+ */
+export function WorkspaceMembers() {
+  const user = useCurrentUser();
+  const { update } = useSession();
+  const { members, isLoading, refetch } = useWorkspaceMembers();
+  const myRole = user?.workspaceRole ?? WorkspaceRole.MEMBER;
+
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<WorkspaceMember | null>(null);
+
+  const changeRole = async (member: WorkspaceMember, role: WorkspaceRole) => {
+    if (pendingId || role === member.role) return;
+    setPendingId(member.userId);
+    try {
+      await apiMutate(`/api/workspaces/current/members/${member.userId}`, {
+        method: "PATCH",
+        body: { role },
+      });
+      toast.success(`${member.name ?? "メンバー"}のロールを${ROLE_LABEL[role]}に変更しました`);
+      await refetch();
+      // 自分のロールを変えた場合はセッション（メニューの出し分け等）へ即反映
+      if (member.userId === user?.id) await update({});
+    } catch (e) {
+      toast.error(e instanceof ApiMutateError ? e.message : "ロールの変更に失敗しました");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const removeMember = async (member: WorkspaceMember) => {
+    setPendingId(member.userId);
+    try {
+      await apiMutate(`/api/workspaces/current/members/${member.userId}`, {
+        method: "DELETE",
+      });
+      toast.success(`${member.name ?? "メンバー"}を除名しました`);
+      await refetch();
+    } catch (e) {
+      toast.error(e instanceof ApiMutateError ? e.message : "除名に失敗しました");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return <p className="m-0 py-2 text-[11.5px] text-ink-faint">読み込み中…</p>;
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        {members.map((m) => {
+          const isSelf = m.userId === user?.id;
+          const canManage = canManageMember(myRole, m.role);
+          return (
+            <div key={m.userId} className="flex items-center gap-2.5 py-1.5">
+              {m.image ? (
+                <Image
+                  src={m.image}
+                  alt=""
+                  width={28}
+                  height={28}
+                  className="h-7 w-7 flex-none rounded-full object-cover"
+                />
+              ) : (
+                <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-brand text-[11px] font-bold text-white">
+                  {memberInitial(m.name)}
+                </span>
+              )}
+              <span className="min-w-0 flex-1 truncate text-[12.5px] font-bold">
+                {m.name ?? "（名前未設定）"}
+                {isSelf && <span className="ml-1 text-[10.5px] font-semibold text-ink-faint">自分</span>}
+              </span>
+              {canManage ? (
+                <Select
+                  value={m.role}
+                  onValueChange={(v) => void changeRole(m, v as WorkspaceRole)}
+                  disabled={pendingId !== null}
+                >
+                  <SelectTrigger className="h-8 w-[104px] flex-none rounded-lg text-[11.5px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ROLES.filter((r) => r === m.role || canAssignRole(myRole, r)).map((r) => (
+                      <SelectItem key={r} value={r} className="text-[12px]">
+                        {ROLE_LABEL[r]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                // ADMIN から見た OWNER の行など、操作不可の相手はロールを表示のみ
+                <span className="flex-none px-2 text-[11.5px] font-semibold text-ink-faint">
+                  {ROLE_LABEL[m.role]}
+                </span>
+              )}
+              {canManage && !isSelf && (
+                <button
+                  type="button"
+                  disabled={pendingId !== null}
+                  onClick={() => setRemoveTarget(m)}
+                  className="h-8 flex-none rounded-lg px-2 text-[11px] font-bold text-danger transition-colors hover:bg-[#FEF3F2] disabled:opacity-50"
+                >
+                  除名
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <AlertDialog
+        open={removeTarget != null}
+        onOpenChange={(open) => !open && setRemoveTarget(null)}
+      >
+        <AlertDialogContent className="max-w-[360px] rounded-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-[15px]">メンバーを除名しますか？</AlertDialogTitle>
+            <AlertDialogDescription className="text-[12.5px]">
+              「{removeTarget?.name ?? "このメンバー"}」をワークスペースから除名します。
+              本人はこのワークスペースの機材・予約にアクセスできなくなります
+              （過去の予約履歴は記録として残ります）。再参加には招待リンクが必要です。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>戻る</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-danger hover:bg-danger/90"
+              onClick={() => {
+                if (removeTarget) void removeMember(removeTarget);
+                setRemoveTarget(null);
+              }}
+            >
+              除名する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/(protected)/settings/_components/WorkspaceSection.tsx
+++ b/app/(protected)/settings/_components/WorkspaceSection.tsx
@@ -6,6 +6,7 @@ import { WorkspaceRole } from "@prisma/client";
 import { toast } from "sonner";
 
 import { useCurrentUser } from "@/hooks/use-current-user";
+import { WorkspaceMembers } from "./WorkspaceMembers";
 
 const ROLE_LABEL: Record<WorkspaceRole, string> = {
   OWNER: "オーナー",
@@ -95,6 +96,13 @@ export function WorkspaceSection() {
               </button>
             </div>
           )}
+        </div>
+      )}
+
+      {isManager && (
+        <div className="border-b border-line-soft py-3.5">
+          <p className="m-0 mb-1.5 text-sm font-bold text-ink">メンバー</p>
+          <WorkspaceMembers />
         </div>
       )}
 

--- a/app/api/workspaces/current/members/[userId]/route.test.ts
+++ b/app/api/workspaces/current/members/[userId]/route.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  membershipFindUniqueMock,
+  membershipCountMock,
+  membershipUpdateMock,
+  membershipDeleteMock,
+  userUpdateManyMock,
+  currentUserMock,
+} = vi.hoisted(() => ({
+  membershipFindUniqueMock: vi.fn(),
+  membershipCountMock: vi.fn(),
+  membershipUpdateMock: vi.fn(),
+  membershipDeleteMock: vi.fn(),
+  userUpdateManyMock: vi.fn(),
+  currentUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    membership: {
+      findUnique: membershipFindUniqueMock,
+      count: membershipCountMock,
+      update: membershipUpdateMock,
+    },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        membership: { delete: membershipDeleteMock },
+        user: { updateMany: userUpdateManyMock },
+      }),
+    ),
+  },
+}));
+vi.mock("@/lib/auth", () => ({
+  currentUser: () => currentUserMock(),
+}));
+
+import { DELETE, PATCH } from "./route";
+
+const patchRequest = (body: unknown) =>
+  new Request("http://localhost/api/workspaces/current/members/t1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+const deleteRequest = () =>
+  new Request("http://localhost/api/workspaces/current/members/t1", { method: "DELETE" });
+const params = { params: Promise.resolve({ userId: "t1" }) };
+
+// findUnique は「実行者(u1)の再検証」と「対象(t1)の取得」の2用途で呼ばれるため、
+// userId で出し分ける。actorRole / targetMembership をテストごとに差し替える。
+let actorRole: string;
+let targetMembership: { id: string; userId: string; workspaceId: string; role: string } | null;
+
+beforeEach(() => {
+  actorRole = "OWNER";
+  targetMembership = { id: "mem-t1", userId: "t1", workspaceId: "ws1", role: "MEMBER" };
+  membershipFindUniqueMock.mockReset();
+  membershipFindUniqueMock.mockImplementation(async ({ where }) =>
+    where.userId_workspaceId.userId === "u1" ? { role: actorRole } : targetMembership
+  );
+  membershipCountMock.mockReset();
+  membershipCountMock.mockResolvedValue(2); // 既定: OWNER は2人いる（最後のOWNERではない）
+  membershipUpdateMock.mockReset();
+  membershipDeleteMock.mockReset();
+  userUpdateManyMock.mockReset();
+  currentUserMock.mockReset();
+  currentUserMock.mockResolvedValue({ id: "u1", role: "USER", currentWorkspaceId: "ws1" });
+});
+
+describe("PATCH /api/workspaces/current/members/[userId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    currentUserMock.mockResolvedValue(undefined);
+    const res = await PATCH(patchRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a plain MEMBER actor", async () => {
+    actorRole = "MEMBER";
+    const res = await PATCH(patchRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(403);
+    expect(membershipUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid role value", async () => {
+    const res = await PATCH(patchRequest({ role: "SUPERUSER" }), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the target is not a member of the current workspace", async () => {
+    targetMembership = null;
+    const res = await PATCH(patchRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("lets an OWNER change any role (MEMBER -> ADMIN)", async () => {
+    const res = await PATCH(patchRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(200);
+    expect(membershipUpdateMock).toHaveBeenCalledWith({
+      where: { id: "mem-t1" },
+      data: { role: "ADMIN" },
+    });
+  });
+
+  it("lets an ADMIN change MEMBER <-> ADMIN", async () => {
+    actorRole = "ADMIN";
+    const res = await PATCH(patchRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(200);
+  });
+
+  it("forbids an ADMIN from promoting anyone to OWNER", async () => {
+    actorRole = "ADMIN";
+    const res = await PATCH(patchRequest({ role: "OWNER" }), params);
+    expect(res.status).toBe(403);
+    expect(membershipUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("forbids an ADMIN from touching an OWNER", async () => {
+    actorRole = "ADMIN";
+    targetMembership = { id: "mem-t1", userId: "t1", workspaceId: "ws1", role: "OWNER" };
+    const res = await PATCH(patchRequest({ role: "MEMBER" }), params);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 when demoting the last OWNER (workspace lockout prevention)", async () => {
+    targetMembership = { id: "mem-t1", userId: "t1", workspaceId: "ws1", role: "OWNER" };
+    membershipCountMock.mockResolvedValue(1);
+    const res = await PATCH(patchRequest({ role: "MEMBER" }), params);
+    expect(res.status).toBe(409);
+    expect(membershipUpdateMock).not.toHaveBeenCalled();
+    expect(membershipCountMock).toHaveBeenCalledWith({
+      where: { workspaceId: "ws1", role: "OWNER" },
+    });
+  });
+
+  it("is a no-op 200 when the role is unchanged", async () => {
+    const res = await PATCH(patchRequest({ role: "MEMBER" }), params);
+    expect(res.status).toBe(200);
+    expect(membershipUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/workspaces/current/members/[userId]", () => {
+  it("removes a member and resets their lastWorkspaceId if it pointed here", async () => {
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(200);
+    expect(membershipDeleteMock).toHaveBeenCalledWith({ where: { id: "mem-t1" } });
+    // 除名した人の現在WSがここを指したままだと次のJWT更新まで403が続くため null に戻す
+    expect(userUpdateManyMock).toHaveBeenCalledWith({
+      where: { id: "t1", lastWorkspaceId: "ws1" },
+      data: { lastWorkspaceId: null },
+    });
+  });
+
+  it("forbids an ADMIN from removing an OWNER", async () => {
+    actorRole = "ADMIN";
+    targetMembership = { id: "mem-t1", userId: "t1", workspaceId: "ws1", role: "OWNER" };
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(403);
+    expect(membershipDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when removing the last OWNER", async () => {
+    targetMembership = { id: "mem-t1", userId: "t1", workspaceId: "ws1", role: "OWNER" };
+    membershipCountMock.mockResolvedValue(1);
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(409);
+    expect(membershipDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a user outside the current workspace", async () => {
+    targetMembership = null;
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/workspaces/current/members/[userId]/route.ts
+++ b/app/api/workspaces/current/members/[userId]/route.ts
@@ -1,0 +1,124 @@
+import { db } from '@/lib/db';
+import { requireWorkspaceManager } from '@/lib/route-helpers';
+import { canAssignRole, canManageMember } from '@/lib/workspace';
+import { MemberRoleSchema } from '@/schemas';
+import { WorkspaceRole } from '@prisma/client';
+import { NextResponse } from 'next/server';
+
+interface Params {
+    params: Promise<{ userId: string }>;
+}
+
+/**
+ * 最後の OWNER の降格・除名を防ぐガード。ワークスペースが管理不能（OWNER ゼロ）に
+ * なる操作は 409 で拒否する。対象が OWNER のときだけ数えれば十分。
+ */
+async function isLastOwner(workspaceId: string, targetRole: WorkspaceRole): Promise<boolean> {
+    if (targetRole !== WorkspaceRole.OWNER) return false;
+    const owners = await db.membership.count({
+        where: { workspaceId, role: WorkspaceRole.OWNER },
+    });
+    return owners <= 1;
+}
+
+// メンバーのロール変更。権限ルールは lib/workspace.ts（OWNER 優位）を参照。
+export async function PATCH(request: Request, { params }: Params) {
+    try {
+        const ctx = await requireWorkspaceManager();
+        if (ctx instanceof NextResponse) return ctx;
+
+        const { userId } = await params;
+        const parsed = MemberRoleSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: parsed.error.issues[0]?.message ?? '入力内容が不正です。' },
+                { status: 400 }
+            );
+        }
+        const newRole = parsed.data.role;
+
+        // 対象はワークスペース込みで引く（他ワークスペースのユーザー id は 404）
+        const target = await db.membership.findUnique({
+            where: { userId_workspaceId: { userId, workspaceId: ctx.workspaceId } },
+        });
+        if (!target) {
+            return NextResponse.json({ error: 'メンバーが見つかりません。' }, { status: 404 });
+        }
+
+        if (!canManageMember(ctx.workspaceRole, target.role) || !canAssignRole(ctx.workspaceRole, newRole)) {
+            return NextResponse.json(
+                { error: 'このロール変更を行う権限がありません。' },
+                { status: 403 }
+            );
+        }
+
+        if (target.role === newRole) {
+            return NextResponse.json({ message: '変更はありません。' }, { status: 200 });
+        }
+
+        // OWNER → 他ロールへ落とす場合、最後の OWNER なら拒否（ワークスペースのロックアウト防止）
+        if (await isLastOwner(ctx.workspaceId, target.role)) {
+            return NextResponse.json(
+                { error: '最後のオーナーは降格できません。先に別のオーナーを任命してください。' },
+                { status: 409 }
+            );
+        }
+
+        await db.membership.update({
+            where: { id: target.id },
+            data: { role: newRole },
+        });
+
+        return NextResponse.json({ message: 'ロールを変更しました。' }, { status: 200 });
+    } catch (error) {
+        console.error('Error updating member role:', error);
+        return NextResponse.json({ error: 'ロールの変更に失敗しました。' }, { status: 500 });
+    }
+}
+
+// メンバーの除名。予約履歴（Reserve）は記録として残す。
+// 除名後の本人アクセスは requireWorkspaceMember の毎リクエスト DB 検証で即座に 403 になる。
+export async function DELETE(request: Request, { params }: Params) {
+    try {
+        const ctx = await requireWorkspaceManager();
+        if (ctx instanceof NextResponse) return ctx;
+
+        const { userId } = await params;
+        const target = await db.membership.findUnique({
+            where: { userId_workspaceId: { userId, workspaceId: ctx.workspaceId } },
+        });
+        if (!target) {
+            return NextResponse.json({ error: 'メンバーが見つかりません。' }, { status: 404 });
+        }
+
+        if (!canManageMember(ctx.workspaceRole, target.role)) {
+            return NextResponse.json(
+                { error: 'このメンバーを除名する権限がありません。' },
+                { status: 403 }
+            );
+        }
+
+        if (await isLastOwner(ctx.workspaceId, target.role)) {
+            return NextResponse.json(
+                { error: '最後のオーナーは除名できません。先に別のオーナーを任命してください。' },
+                { status: 409 }
+            );
+        }
+
+        await db.$transaction(async (tx) => {
+            await tx.membership.delete({ where: { id: target.id } });
+            // 除名した人の「現在のワークスペース」がここを指したままだと、次回の
+            // JWT リフレッシュまで 403 が続く。null に戻して残りの所属へフォールバックさせる
+            // （所属ゼロなら /workspaces/new へ誘導される既存動線）。
+            await tx.user.updateMany({
+                where: { id: userId, lastWorkspaceId: ctx.workspaceId },
+                data: { lastWorkspaceId: null },
+            });
+        });
+
+        return NextResponse.json({ message: 'メンバーを除名しました。' }, { status: 200 });
+    } catch (error) {
+        console.error('Error removing member:', error);
+        return NextResponse.json({ error: 'メンバーの除名に失敗しました。' }, { status: 500 });
+    }
+}

--- a/app/api/workspaces/current/members/route.test.ts
+++ b/app/api/workspaces/current/members/route.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  membershipFindUniqueMock,
+  membershipFindManyMock,
+  userFindManyMock,
+  currentUserMock,
+} = vi.hoisted(() => ({
+  membershipFindUniqueMock: vi.fn(),
+  membershipFindManyMock: vi.fn(),
+  userFindManyMock: vi.fn(),
+  currentUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    membership: {
+      findUnique: membershipFindUniqueMock,
+      findMany: membershipFindManyMock,
+    },
+    user: { findMany: userFindManyMock },
+  },
+}));
+vi.mock("@/lib/auth", () => ({
+  currentUser: () => currentUserMock(),
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  membershipFindUniqueMock.mockReset();
+  membershipFindUniqueMock.mockResolvedValue({ role: "ADMIN" });
+  membershipFindManyMock.mockReset();
+  membershipFindManyMock.mockResolvedValue([]);
+  userFindManyMock.mockReset();
+  userFindManyMock.mockResolvedValue([]);
+  currentUserMock.mockReset();
+  currentUserMock.mockResolvedValue({ id: "u1", role: "USER", currentWorkspaceId: "ws1" });
+});
+
+describe("GET /api/workspaces/current/members", () => {
+  it("returns 401 when unauthenticated", async () => {
+    currentUserMock.mockResolvedValue(undefined);
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    expect(membershipFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a plain MEMBER (role-sensitive list is manager-only)", async () => {
+    membershipFindUniqueMock.mockResolvedValue({ role: "MEMBER" });
+
+    const res = await GET();
+
+    expect(res.status).toBe(403);
+    expect(membershipFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns members of the current workspace sorted by role then name", async () => {
+    membershipFindManyMock.mockResolvedValue([
+      { userId: "m1", role: "MEMBER", createdAt: new Date("2026-07-01") },
+      { userId: "o1", role: "OWNER", createdAt: new Date("2026-07-01") },
+      { userId: "a1", role: "ADMIN", createdAt: new Date("2026-07-02") },
+    ]);
+    userFindManyMock.mockResolvedValue([
+      { id: "m1", name: "部員", image: null },
+      { id: "o1", name: "部長", image: "https://example.com/o.png" },
+      { id: "a1", name: "副部長", image: null },
+    ]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.map((m: { userId: string }) => m.userId)).toEqual(["o1", "a1", "m1"]);
+    expect(body[0]).toMatchObject({ userId: "o1", name: "部長", role: "OWNER" });
+    // ワークスペースで絞っている（テナント境界）
+    expect(membershipFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { workspaceId: "ws1" } })
+    );
+  });
+});

--- a/app/api/workspaces/current/members/route.ts
+++ b/app/api/workspaces/current/members/route.ts
@@ -1,0 +1,46 @@
+import { db } from '@/lib/db';
+import { requireWorkspaceManager } from '@/lib/route-helpers';
+import { WorkspaceRole } from '@prisma/client';
+import { NextResponse } from 'next/server';
+
+// ロール表示順（OWNER → ADMIN → MEMBER）
+const ROLE_ORDER: Record<WorkspaceRole, number> = { OWNER: 0, ADMIN: 1, MEMBER: 2 };
+
+// 現在のワークスペースのメンバー一覧（設定ページのメンバー管理 UI 用）。
+// ロール情報を含むため管理者（OWNER/ADMIN）のみ。氏名だけの一覧は /api/users を使う。
+export async function GET() {
+    try {
+        const ctx = await requireWorkspaceManager();
+        if (ctx instanceof NextResponse) return ctx;
+
+        // Membership は生FKスタイル（リレーション宣言なし）のため2段引き
+        const memberships = await db.membership.findMany({
+            where: { workspaceId: ctx.workspaceId },
+            select: { userId: true, role: true, createdAt: true },
+        });
+        const users = await db.user.findMany({
+            where: { id: { in: memberships.map((m) => m.userId) } },
+            select: { id: true, name: true, image: true },
+        });
+        const userOf = new Map(users.map((u) => [u.id, u]));
+
+        const members = memberships
+            .map((m) => ({
+                userId: m.userId,
+                name: userOf.get(m.userId)?.name ?? null,
+                image: userOf.get(m.userId)?.image ?? null,
+                role: m.role,
+                createdAt: m.createdAt,
+            }))
+            .sort(
+                (a, b) =>
+                    ROLE_ORDER[a.role] - ROLE_ORDER[b.role] ||
+                    (a.name ?? "").localeCompare(b.name ?? "", "ja")
+            );
+
+        return NextResponse.json(members, { status: 200 });
+    } catch (error) {
+        console.error('Error fetching members:', error);
+        return NextResponse.json({ error: 'メンバーの取得に失敗しました。' }, { status: 500 });
+    }
+}

--- a/hooks/use-workspace-members.ts
+++ b/hooks/use-workspace-members.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import type { WorkspaceRole } from "@prisma/client";
+import { useCachedEndpoint } from "@/hooks/use-cached-endpoint";
+
+export interface WorkspaceMember {
+  userId: string;
+  name: string | null;
+  image: string | null;
+  role: WorkspaceRole;
+  createdAt: string;
+}
+
+/**
+ * 現在のワークスペースのメンバー一覧（設定ページのメンバー管理用）。
+ * API は管理者（OWNER/ADMIN）専用なので、管理者 UI からのみ呼ぶこと。
+ */
+export function useWorkspaceMembers() {
+  const { data: members, isLoading, isError, refetch } =
+    useCachedEndpoint<WorkspaceMember>("/api/workspaces/current/members");
+  return { members, isLoading, isError, refetch };
+}

--- a/lib/workspace.test.ts
+++ b/lib/workspace.test.ts
@@ -1,11 +1,50 @@
 import { describe, expect, it } from "vitest";
+import { WorkspaceRole } from "@prisma/client";
 
-import { DEFAULT_WORKSPACE_ID, DEFAULT_WORKSPACE_SLUG } from "./workspace";
+import {
+  DEFAULT_WORKSPACE_ID,
+  DEFAULT_WORKSPACE_SLUG,
+  canAssignRole,
+  canManageMember,
+} from "./workspace";
+
+const { OWNER, ADMIN, MEMBER } = WorkspaceRole;
 
 describe("workspace constants", () => {
   it("keeps the fixed id in sync with the migration (ws_abs_default)", () => {
     // migration 20260707171315 の INSERT / schema.prisma の @default と一致していること
     expect(DEFAULT_WORKSPACE_ID).toBe("ws_abs_default");
     expect(DEFAULT_WORKSPACE_SLUG).toBe("abs");
+  });
+});
+
+describe("canManageMember（OWNER 優位）", () => {
+  it.each([
+    // [actor, target, expected]
+    [OWNER, OWNER, true],
+    [OWNER, ADMIN, true],
+    [OWNER, MEMBER, true],
+    [ADMIN, OWNER, false], // ADMIN は OWNER に触れない
+    [ADMIN, ADMIN, true],
+    [ADMIN, MEMBER, true],
+    [MEMBER, OWNER, false],
+    [MEMBER, ADMIN, false],
+    [MEMBER, MEMBER, false],
+  ] as const)("actor=%s target=%s → %s", (actor, target, expected) => {
+    expect(canManageMember(actor, target)).toBe(expected);
+  });
+});
+
+describe("canAssignRole（OWNER の任命は OWNER のみ）", () => {
+  it.each([
+    [OWNER, OWNER, true],
+    [OWNER, ADMIN, true],
+    [OWNER, MEMBER, true],
+    [ADMIN, OWNER, false], // ADMIN は OWNER を任命できない
+    [ADMIN, ADMIN, true],
+    [ADMIN, MEMBER, true],
+    [MEMBER, MEMBER, false],
+  ] as const)("actor=%s newRole=%s → %s", (actor, newRole, expected) => {
+    expect(canAssignRole(actor, newRole)).toBe(expected);
   });
 });

--- a/lib/workspace.ts
+++ b/lib/workspace.ts
@@ -1,3 +1,5 @@
+import { WorkspaceRole } from "@prisma/client";
+
 /**
  * 既定ワークスペース（既存の放送部）。migration
  * 20260707171315_add_workspaces_and_tenant_columns で作成される固定行で、
@@ -10,3 +12,31 @@
  */
 export const DEFAULT_WORKSPACE_ID = "ws_abs_default";
 export const DEFAULT_WORKSPACE_SLUG = "abs";
+
+/*
+ * メンバー管理（ロール変更・除名）の権限ルール。OWNER 優位:
+ *   - OWNER は誰に対しても操作でき、どのロールも付与できる
+ *   - ADMIN は MEMBER/ADMIN に対してのみ操作でき、OWNER の付与・変更はできない
+ *   - MEMBER は操作不可（そもそも requireWorkspaceManager で弾かれる）
+ * 「最後の OWNER の降格・除名禁止」は件数を要するためルート側でガードする。
+ */
+
+/** actorRole が targetRole のメンバーを操作（ロール変更・除名）できるか。 */
+export function canManageMember(
+  actorRole: WorkspaceRole,
+  targetRole: WorkspaceRole
+): boolean {
+  if (actorRole === WorkspaceRole.OWNER) return true;
+  if (actorRole === WorkspaceRole.ADMIN) return targetRole !== WorkspaceRole.OWNER;
+  return false;
+}
+
+/** actorRole が newRole を付与できるか（OWNER の任命は OWNER のみ）。 */
+export function canAssignRole(
+  actorRole: WorkspaceRole,
+  newRole: WorkspaceRole
+): boolean {
+  if (actorRole === WorkspaceRole.OWNER) return true;
+  if (actorRole === WorkspaceRole.ADMIN) return newRole !== WorkspaceRole.OWNER;
+  return false;
+}

--- a/prisma/migrations/20260708070000_add_timestamps_and_promote_owners/migration.sql
+++ b/prisma/migrations/20260708070000_add_timestamps_and_promote_owners/migration.sql
@@ -1,0 +1,49 @@
+-- 監査カラムの整備。既存行の created_at は本 migration の適用時刻になる
+-- （それ以前の真の作成日時は記録されていない。以後の新規行から正確な値が入る）。
+-- updated_at の自動更新は Prisma の @updatedAt（クライアント側）が担う。
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "user_settings" ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                            ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "List" ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                   ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Reserve" ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                      ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Tag" ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "memberships" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "workspace_invites" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "feedback" ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- ---------------------------------------------------------------------------
+-- OWNER 昇格 backfill（手書き）: OWNER 優位のロール管理ルール導入にあたり、
+-- OWNER 不在のワークスペース（backfill 由来の既定ワークスペース）では
+-- 既存の ADMIN を OWNER へ昇格する（P4 以前に全権を持っていた運用者に相当）。
+-- セルフサーブ作成のワークスペースは作成者が既に OWNER のため影響しない。
+-- ---------------------------------------------------------------------------
+
+UPDATE "memberships" m SET "role" = 'OWNER'
+WHERE m."role" = 'ADMIN'
+  AND NOT EXISTS (
+    SELECT 1 FROM "memberships" o
+    WHERE o."workspace_id" = m."workspace_id" AND o."role" = 'OWNER'
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,9 @@ model User {
   twoFactorConfirmation TwoFactorConfirmation?
   settings      UserSettings?
   feedbacks     Feedback[]
+  // 監査カラム。migration 以前の既存行の createdAt は適用時刻になる（真の登録日は不明）。
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @default(now()) @updatedAt @map("updated_at")
 
   @@map("users")
 }
@@ -48,6 +51,7 @@ model Feedback {
   path      String?  // 送信元ページ（自動付与）
   resolved  Boolean  @default(false)
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@index([resolved, createdAt])
   @@map("feedback")
@@ -68,6 +72,8 @@ model UserSettings {
   lineNotifyEnabled       Boolean      @default(false) @map("line_notify_enabled")
   lineUserId              String?      @unique @map("line_user_id")
   calendarDefaultView     CalendarView @default(MONTH) @map("calendar_default_view")
+  createdAt               DateTime     @default(now()) @map("created_at")
+  updatedAt               DateTime     @default(now()) @updatedAt @map("updated_at")
 
   @@map("user_settings")
 }
@@ -136,6 +142,7 @@ model Workspace {
   name      String
   slug      String   @unique
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@map("workspaces")
 }
@@ -156,6 +163,7 @@ model Membership {
   workspaceId String        @map("workspace_id")
   role        WorkspaceRole @default(MEMBER)
   createdAt   DateTime      @default(now()) @map("created_at")
+  updatedAt   DateTime      @default(now()) @updatedAt @map("updated_at")
 
   @@unique([userId, workspaceId])
   @@index([workspaceId])
@@ -173,6 +181,7 @@ model WorkspaceInvite {
   usedCount   Int           @default(0) @map("used_count")
   createdBy   String?       @map("created_by")
   createdAt   DateTime      @default(now()) @map("created_at")
+  updatedAt   DateTime      @default(now()) @updatedAt @map("updated_at")
 
   @@map("workspace_invites")
 }
@@ -187,6 +196,8 @@ model List {
   // テナント境界。全 create 経路が明示的に渡す（移行期の DB デフォルト
   // 'ws_abs_default' は撤去済み。書き忘れは silent な越境ではなくエラーになる）。
   workspaceId String @map("workspace_id")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
   // GET /api/lists・/api/calendar のワークスペース絞り込みに効く。
   @@index([workspaceId])
@@ -208,6 +219,8 @@ model Reserve {
   returnedAt DateTime? @map("returned_at")
   // テナント境界（List と同じ方針）
   workspaceId String @map("workspace_id")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
   // POST の重複(期間重なり)チェック route.ts の findFirst({ list_id, start<=E, end>=S }) と
   // ?list_id= フィルタに効く。等値 list_id を先頭、範囲 start を第2列に。
@@ -226,6 +239,8 @@ model Tag {
   sortOrder Int    @default(0) @map("sort_order")
   // テナント境界（List と同じ方針）
   workspaceId String @map("workspace_id")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
   // GET /api/tags・/api/calendar のワークスペース絞り込みに効く。
   @@index([workspaceId])

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -111,3 +111,9 @@ export const WorkspaceSchema = z.object({
         message: "ワークスペース名は50文字以内で入力してください"
     }),
 })
+
+export const MemberRoleSchema = z.object({
+    role: z.enum(["OWNER", "ADMIN", "MEMBER"], {
+        message: "ロールの指定が不正です",
+    }),
+})


### PR DESCRIPTION
## 概要

1. **メンバー権限管理**: 管理者が設定ページからワークスペースのメンバーのロール変更・除名をできるようにする
2. **監査カラム整備**: created_at / updated_at が無かったテーブルに追加（User に登録日、Reserve に予約作成日など）

## 1. メンバー権限管理

設定ページのワークスペース欄（OWNER/ADMIN のみ表示）にメンバー一覧を追加。

**権限ルール（OWNER 優位・サーバー側で強制）**

| 実行者 | できること |
|---|---|
| OWNER | 誰のロールでも変更・除名（OWNER の任命も可） |
| ADMIN | MEMBER↔ADMIN の変更と除名のみ。OWNER には操作不可・OWNER 任命不可 |
| MEMBER | 操作不可（メンバー一覧 API 自体が 403） |

- **最後のオーナーの降格・除名は 409 で拒否**（ワークスペースのロックアウト防止）
- 除名: 予約履歴は記録として残す。アクセスは即時 403（membership を毎リクエスト DB 検証しているため）。除名された人は残りの所属へフォールバック、所属ゼロなら /workspaces/new へ誘導
- API: `GET/PATCH/DELETE /api/workspaces/current/members(/[userId])`。ルールは `lib/workspace.ts` の純関数（canManageMember / canAssignRole）で単体テスト済み

**OWNER 昇格 backfill**: backfill 由来の既定ワークスペース（放送部）には OWNER が不在のため、migration 内で **OWNER 不在のワークスペースの既存 ADMIN を OWNER へ昇格**する（本番では運用者が自動的にオーナーになる）。セルフサーブ作成の WS は影響なし。

## 2. 監査カラム

- created_at + updated_at 追加: **User / UserSettings / List / Reserve / Tag**
- updated_at 追加: **Workspace / Membership / WorkspaceInvite / Feedback**
- NextAuth 系（Account・各トークン）は対象外（アダプター管理／短命データ）
- ⚠️ 既存行の created_at は migration 適用時刻になる（過去の真の作成日は未記録だったため）。以後の新規行から正確

## マイグレーション

`20260708070000_add_timestamps_and_promote_owners` 1本（カラム追加＋OWNER昇格。無停止・旧コード互換）。CI の `prisma migrate deploy` で適用。

## 検証

- vitest 530 件・lint・本番ビルド全パス（権限マトリクスの単体テスト・API ルートテストを追加）
- dev 環境でランタイム検証済み: ロール変更マトリクス全パターン（ADMIN→OWNER 操作 403 / 最後のオーナー降格・除名 409 / OWNER 2人なら自己降格可）、除名の即時 403・lastWorkspaceId リセット、設定ページ UI（ロール Select・除名確認・自分の行は除名不可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnZeQcYNkZcBYeDEbGGm5J