### PR TITLE
fix: 本番の管理者不在を救済（グローバルADMINをOWNERへ昇格）

### DIFF
--- a/prisma/migrations/20260708080000_promote_global_admins_to_owner/migration.sql
+++ b/prisma/migrations/20260708080000_promote_global_admins_to_owner/migration.sql
@@ -1,0 +1,22 @@
+-- 管理者不在ワークスペースの救済。
+--
+-- P1 の backfill は「users.role=ADMIN のユーザーを WS ADMIN に」する設計だったが、
+-- 本番では backfill 実行時点で role=ADMIN のユーザーが存在せず、全員 MEMBER になった。
+-- P4 でグローバル ADMIN フォールバックを廃止したため、そのままでは誰も
+-- 機材管理・招待発行ができない。直前の migration（既存 WS ADMIN → OWNER 昇格）も
+-- 「WS ADMIN がいる」前提のため効かない。
+--
+-- ここでは OWNER も ADMIN もいないワークスペースに限り、グローバル role=ADMIN の
+-- ユーザー（運用者）の membership を OWNER へ昇格する。管理者が既にいる
+-- ワークスペースには影響しない（dev・セルフサーブ作成の WS では no-op）。
+
+UPDATE "memberships" m SET "role" = 'OWNER'
+FROM "users" u
+WHERE m."user_id" = u."id"
+  AND u."role" = 'ADMIN'
+  AND m."role" = 'MEMBER'
+  AND NOT EXISTS (
+    SELECT 1 FROM "memberships" x
+    WHERE x."workspace_id" = m."workspace_id"
+      AND x."role" IN ('OWNER', 'ADMIN')
+  );


### PR DESCRIPTION
## 問題

本番 DB を確認したところ、**ワークスペースの OWNER/ADMIN がゼロ**（全員 MEMBER）でした。P1 の backfill 実行時点で `users.role=ADMIN` のユーザーが存在しなかったためです。P4 でグローバル ADMIN のフォールバックを廃止したため、現在の本番では**誰も機材管理・カテゴリ編集・招待発行・メンバー管理ができません**（PR #61 の OWNER 昇格 migration は「WS ADMIN がいる」前提のため no-op でした）。

## 修正

migration 1本のみ: **OWNER も ADMIN もいないワークスペースに限り**、グローバル `role=ADMIN` のユーザー（運用者 = daichi8120@gmail.com）の membership を OWNER へ昇格します。

- 管理者が既にいるワークスペースには影響なし（dev で本番相当の状況を再現し、対象1行のみ昇格・既存 WS 無変化を検証済み）
- **マージすると運用者が放送部のオーナーになり、機材管理・招待発行・メンバー管理が使えるようになります**

## マージ後の確認

設定ページのワークスペース欄で、自分のロールが「オーナー」表示になり「メンバー」一覧と「リンクを発行」が出ていれば復旧です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnZeQcYNkZcBYeDEbGGm5J